### PR TITLE
fix: FuncCond parametrizing

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -2,6 +2,10 @@
 Version history
 ===============
 
+- ``2.1.1``
+
+    - Fix: bug in func condition parametrizing
+
 - ``2.1.0``
 
     - Add: Condition API (``rocketry.conds``) for easy alternative for the string syntax

--- a/rocketry/conditions/func.py
+++ b/rocketry/conditions/func.py
@@ -97,7 +97,8 @@ class FuncCond(BaseCondition):
 
     def observe(self, **kwargs) -> bool:
         func_params = Parameters._from_signature(self.func, **kwargs)
-        return self.get_state(*self.args, **self.kwargs, **func_params)
+        param_dict = func_params.materialize(**kwargs)
+        return self.get_state(*self.args, **self.kwargs, **param_dict)
 
     def get_state(self, *args, **kwargs):
         return self.func(*args, **kwargs)

--- a/rocketry/test/app/test_cond_api.py
+++ b/rocketry/test/app/test_cond_api.py
@@ -2,7 +2,7 @@
 import logging
 
 from rocketry import Rocketry
-from rocketry.args.builtin import Return
+from rocketry.args.builtin import Return, Task
 from rocketry.conditions import TaskStarted
 from rocketry.conditions.api import after_success
 
@@ -75,7 +75,8 @@ def test_custom_cond():
 
     # Creating some tasks
     @app.cond('is foo')
-    def is_foo():
+    def is_foo(task=Task()):
+        assert task.name == "do_things"
         return True
 
     @app.task(true & is_foo)


### PR DESCRIPTION
Making this possible:

```python
from rocketry.args import Task

@app.cond()
def is_foo(task=Task()):
    ...
```