### PR TITLE
Fix: task status discontinuity in restart

### DIFF
--- a/docs/handbooks/index.rst
+++ b/docs/handbooks/index.rst
@@ -13,3 +13,4 @@ operates.
 
    conditions/index
    config
+   logging

--- a/docs/handbooks/logging.rst
+++ b/docs/handbooks/logging.rst
@@ -1,0 +1,153 @@
+
+.. _handbook-logging:
+
+Task Logging
+============
+
+Rocketry's logging system is based on 
+`logging library (standard library) <https://docs.python.org/3/library/logging.html>`_
+and on `Red Bird <https://red-bird.readthedocs.io/>`_.
+Rocketry uses Logging's logging mechanisms and extend
+them with Red Bird in order to read from the logs.
+
+Mechanism
+---------
+
+There is a logger called ``rocketry.task`` which is 
+used to log the tasks' actions. This logger should 
+have one repo handler (``redbird.logging.RepoHandler``)
+which logs the task actions to a repository that 
+can be read using Red Bird's unified query syntax. 
+The logs, appart from failure, are logged with 
+level ``INFO`` thus the logger should not filter
+this level off.
+
+Types of task actions:
+
+- ``run``: Logged when a task starts.
+- ``success``: Logged when a task finishes without exceptions.
+- ``fail``: Logged when a task finishes with an error.
+- ``terminate``: Logged when a task is terminated before it finished.
+- ``inaction``: Special action to indicate the task did nothing. Requires raising a special exception.
+
+
+Log Record
+----------
+
+Each log record in the repository should contain at 
+least the following fields or attributes:
+
+- ``created``: Timestamp when the log record was created (Logging library creates).
+- ``task_name``: Name of the task.
+- ``action``: What the log was about. Either *run*, *success*, *fail*, *terminate* or *inaction*. 
+
+You may add any other field or attribute from what the Logging 
+library creates or create attributes your own.
+
+Here is a minimal example of a log record model that Red Bird 
+accepts:
+
+.. code-block:: python
+
+    from pydantic import BaseModel
+
+    class MinimalRecord(BaseModel):
+        task_name: str
+        action: str
+        created: float
+
+Log record models are passed to the repo handlers to specify the data
+format in which our logs are. We take a look into this in a bit.
+
+Here are some premade log record models you may use:
+
+- ``rocketry.log.MinimalRecord``: Bare minimum for the logging to work.
+- ``rocketry.log.LogRecord``: Has the typical elements of `logging.LogRecord <https://docs.python.org/3/library/logging.html#logging.LogRecord>`_ and extras required by rocketry.
+- ``rocketry.log.MinimalRecord``: Has the same as ``LogRecord`` but also includes start, end and runtimes.
+
+
+Setting Up Repo to a Logger
+---------------------------
+
+By default, Rocketry creates a repo handler with ``MemoryRepo``
+in it. This handler logs the records only to an in-memory Python
+list that is not maintained when the interpreter is closed.
+
+You may want to log the records to disk in order to maintain
+persistence in scheduler's state in case of restart or shutdown. 
+
+First, we fetch the task logger:
+
+.. code-block:: python
+
+    import logging
+    logger = logging.getLogger('rocketry.task')
+
+Here is an example to log to a CSV file:
+
+.. code-block:: python
+
+    from rocketry.log import MinimalRecord
+
+    from redbird.repos import CSVFileRepo
+    from redbird.logging import RepoHandler
+
+    # Creating the repo
+    repo = CSVFileRepo(filename="path/to/repo.csv", model=MinimalRecord)
+
+    # Adding the repo to the logger
+    logger = logging.getLogger('rocketry.task')
+    handler = RepoHandler(repo=repo)
+    logging.addHander(handler)
+
+Another common pattern is to log the records to a 
+SQL database. This can be done with SQLAlchemy:
+
+.. code-block:: python
+
+    from redbird.repos import SQLRepo
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite:///app.db")
+    repo = SQLRepo(engine=engine, table="tasks", if_missing="create", model=MinimalRecord, id_field="created")
+    
+    handler = RepoHandler(repo=repo)
+    logging.addHander(handler)
+
+Read more about repositories from `Red Bird's documentation <https://red-bird.readthedocs.io/>`_.
+
+Querying the Logger
+-------------------
+
+Here is an illustration of getting the repository:
+
+.. code-block:: python
+
+    import logging
+    logger = logging.getLogger('rocketry.task')
+    for handler in logger.handlers:
+        if hasattr(handler, "repo"):
+            break
+
+    repo = handler.repo
+
+Then we can query this repo:
+
+.. code-block:: python
+
+    repo.filter_by(task_name="my_task", action="run").all()
+
+The ``task_name`` is already injected if you
+call the logger in a task. Tasks use a ``TaskAdapter``
+that does this trick:
+
+.. code-block:: python
+
+    @app.task()
+    def do_things():
+        ...
+
+    task_logger = app.session['do_things'].logger
+    task_logger.filter_by(action="run").all()
+
+Read more about querying from `Red Bird's documentation <https://red-bird.readthedocs.io/>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ applications. It is simple, clean and extensive.
    <details>
    <summary><a>Dislike the syntax?</a></summary>
 
-You can also use the condition API for the 
+You can also use the condition API:
 
 .. literalinclude:: /code/demos/minimal.py
     :language: py

--- a/docs/tutorial/intermediate.rst
+++ b/docs/tutorial/intermediate.rst
@@ -226,8 +226,8 @@ An example of the task argument:
 
 This is more advanced and we will get to the usage of these later.
 
-Customizing Logging Handlers
-----------------------------
+Task Logging
+------------
 
 Rocketry uses `Red Bird's <https://red-bird.readthedocs.io/>`_
 `logging handler <https://red-bird.readthedocs.io/en/latest/logging_handler.html>`_
@@ -238,8 +238,37 @@ to create a unified interface to read the logs regardless
 if they are stored to a CSV file, SQL database or to 
 a plain Python list in memory.
 
+Log to Repository
+^^^^^^^^^^^^^^^^^
+
+By default, the logs are put to a Python list and they are gone
+if the scheduler is restarted. In many cases this is undesired
+as the scheduler does not know which task had already run,
+succeeded or failed in case of restart. Therefore you might want
+to store the log records to a disk by changing the default log 
+repository. 
+
+The simplest way to configure the location of the logs is to
+pass the new repo as ``logger_repo``:
+
+.. code-block:: python
+
+    from rocketry import Rocketry
+    from rocketry.log import MinimalRecord
+    from redbird.repos import CSVFileRepo
+
+    repo = CSVFileRepo(filename="tasks.csv", model=MinimalRecord)
+    app = Rocketry(logger_repo=repo)
+
+In the example above, we changed the log records to go to a CSV file
+called *tasks.csv*. We also specified a log record format that contains
+the bare minimum. Read more about logging :ref:`in the logging handbook <handbook-logging>`.
+
+Add Another Log Handlers
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 As the logger is simply extension of `the logging library <https://docs.python.org/3/library/logging.html>`_,
-you may add other logging handlers as well: 
+you can also add other logging handlers as well: 
 
 .. code-block:: python
 
@@ -261,28 +290,3 @@ you may add other logging handlers as well:
     Make sure the logger ``rocketry.task`` has at least 
     one ``redbird.logging.RepoHandler`` in handlers or 
     the system cannot read the log information.
-
-Reading from the Logs
----------------------
-
-Reading programmatically from the logs is easy due to unified 
-querying syntax of Red Bird.
-
-We first need to find the handler that has the repository
-and then we can query it:
-
-.. code-block:: python
-
-    import logging
-    
-    task_logger = logging.getLogger('rocketry.task')
-
-    # Getting a RepoHandler
-    for handler in task_logger.handlers:
-        if hasattr(handler, "repo"):
-            break
-    
-    # Query all logs from the handler
-    handler.filter_by().all()
-
-Read more about the querying from `Red Bird's documentation <https://red-bird.readthedocs.io/en/latest/>`_

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -2,6 +2,11 @@
 Version history
 ===============
 
+- ``2.1.2``
+
+    - Fix: Bug in task persistence. Task last action times were not queried.
+    - Docs: Added logging handbook.
+
 - ``2.1.1``
 
     - Fix: bug in func condition parametrizing

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -732,17 +732,16 @@ class Task(RedBase, BaseModel):
         self.last_inaction = self._get_last_action("inaction", from_logs=True)
 
         times = {
-            "run": self.last_run,
-            "success": self.last_success,
-            "fail": self.last_fail,
-            "terminate": self.last_terminate,
-            "inaction": self.last_inaction,
+            name: getattr(self, f"last_{name}")
+            for name in ('run', 'success', 'fail', 'terminate', 'inaction')
+            if getattr(self, f"last_{name}") is not None
         }
 
-        self.status = max(
-            times, 
-            key=times.get
-        )
+        if times:
+            self.status = max(
+                times, 
+                key=times.get
+            )
 
     def get_default_name(self, **kwargs):
         """Create a name for the task when name was not passed to initiation of

--- a/rocketry/test/task/func/test_logging.py
+++ b/rocketry/test/task/func/test_logging.py
@@ -7,12 +7,59 @@ from queue import Empty
 from redbird.logging import RepoHandler
 
 from rocketry import Session
-from rocketry.log.log_record import MinimalRecord
+from rocketry.log.log_record import  MinimalRecord
 
 from rocketry.tasks import FuncTask
 
 def run_success():
     pass
+
+@pytest.mark.parametrize("optimized", [True, False])
+@pytest.mark.parametrize("last_status", ["run", "success", "fail", "inaction", "terminate"])
+def test_set_cached_in_init(session, optimized, last_status):
+    session.config.force_status_from_logs = not optimized
+
+    logger = logging.getLogger("rocketry.task")
+    for handler in logger.handlers:
+        if hasattr(handler, "repo"):
+            repo = handler.repo
+
+    times = {
+        "run": 946677600.0,
+        "success": 1656709200.0,
+        "fail": 1656795600.0,
+        "terminate": 1656882000.0,
+        "inaction":1656968400.0,
+    }
+    
+
+    # A log record that should not be used
+    for action, created in times.items():
+        repo.add(MinimalRecord(
+            task_name="mytask",
+            action=action,
+            created=created
+        ))
+    # Add one extra (which should be used instead of what we did above) 
+    times[last_status] = 1752958800.0
+    repo.add(MinimalRecord(
+        task_name="mytask",
+        action=last_status,
+        created=1752958800.0
+    ))
+
+    # Creating the task
+    task = FuncTask(
+        lambda : None,
+        execution="main",
+        name="mytask",
+        session=session
+    )
+    for action, created in times.items():
+        dt = datetime.datetime.fromtimestamp(created)
+        last_action_value = getattr(task, f"last_{action}")
+        assert last_action_value == dt
+    assert task.status == last_status
 
 def test_running(tmpdir, session):
     

--- a/rocketry/test/task/func/test_logging.py
+++ b/rocketry/test/task/func/test_logging.py
@@ -213,13 +213,13 @@ def test_without_handlers_status_warnings(tmpdir, session):
     
     # Test warnings
     expected_warnings = [
-        'Logger rocketry.task cannot be read. Logging is set to memory. To supress this warning, please set a handler that can be read (redbird.logging.RepoHandler)'
-        #"Logger 'rocketry.task.test' for task 'task 1' does not have ability to be read. Past history of the task cannot be utilized.",
-        #"Task 'task 1' logger is not readable. Latest run unknown.",
-        #"Task 'task 1' logger is not readable. Latest success unknown.",
-        #"Task 'task 1' logger is not readable. Latest fail unknown.",
-        #"Task 'task 1' logger is not readable. Latest terminate unknown.",
-        #"Task 'task 1' logger is not readable. Latest inaction unknown."
+        'Logger rocketry.task cannot be read. Logging is set to memory. To supress this warning, please set a handler that can be read (redbird.logging.RepoHandler)',
+        "Logger 'rocketry.task.test' for task 'task 1' does not have ability to be read. Past history of the task cannot be utilized.",
+        "Task 'task 1' logger is not readable. Latest run unknown.",
+        "Task 'task 1' logger is not readable. Latest success unknown.",
+        "Task 'task 1' logger is not readable. Latest fail unknown.",
+        "Task 'task 1' logger is not readable. Latest terminate unknown.",
+        "Task 'task 1' logger is not readable. Latest inaction unknown."
     ]
     actual_warnings = [str(warn.message) for warn in warns]
     assert expected_warnings == actual_warnings


### PR DESCRIPTION
Previously the ``last_run``, ``last_success``, ``last_fail`` etc. were not fetched causing discontinuity if the scheduler was restarted (and logging repo is not ``MemoryRepo``).

Also updated docs a bit.