### PR TITLE
ENH: Add async tasks

### DIFF
--- a/rocketry/application.py
+++ b/rocketry/application.py
@@ -60,6 +60,12 @@ class Rocketry(_AppMixin):
         self.session.set_as_default()
         self.session.start()
 
+    async def serve(self, debug=False):
+        "Run the scheduler"
+        self.session.config.debug = debug
+        self.session.set_as_default()
+        await self.session.serve()
+
     def cond(self, syntax: Union[str, Pattern, List[Union[str, Pattern]]]=None):
         "Create a condition (decorator)"
         return FuncCond(syntax=syntax, session=self.session, decor_return_func=False)

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -425,10 +425,10 @@ class Scheduler(RedBase):
         else:
             await self.terminate_all(reason="shutdown")
 
-    def wait_task_alive(self):
+    async def wait_task_alive(self):
         """Wait till all, especially threading tasks, are finished."""
         while self.n_alive > 0:
-            time.sleep(0.005)
+            await self._hibernate()
 
     async def shut_down(self, traceback=None, exception=None):
         """Shut down the scheduler.
@@ -464,8 +464,7 @@ class Scheduler(RedBase):
         self.logger.info(f"Shutting down tasks...")
         await self._shut_down_tasks(traceback, exception)
 
-        if not self.session.config.instant_shutdown:
-            self.wait_task_alive() # Wait till all tasks' threads and processes are dead
+        await self.wait_task_alive() # Wait till all tasks' threads and processes are dead
 
         # Running hooks
         hooker.postrun()

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -475,14 +475,13 @@ class Scheduler(RedBase):
         if isinstance(exception, SchedulerRestart):
             # Clean up finished, restart is finally
             # possible
-            self._restart()
+            await self._restart()
 
-    def _restart(self):
+    async def _restart(self):
         """Restart the scheduler by creating a new process
         on the temporary run script where the scheduler's is
         process is started.
         """
-        # TODO
         # https://stackoverflow.com/a/35874988
         self.logger.debug(f"Restarting...", extra={"action": "restart"})
         python = sys.executable
@@ -504,7 +503,7 @@ class Scheduler(RedBase):
         elif restarting == "recall":
             # Mostly useful for testing.
             # Restart by calling the self.__call__ again 
-            return self()
+            await asyncio.create_task(self.serve()) 
         else:
             raise ValueError(f"Invalid restaring: {restarting}")
 

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -1,4 +1,5 @@
 
+import asyncio
 from multiprocessing import cpu_count
 import multiprocessing
 from typing import TYPE_CHECKING, Callable, Optional, Union
@@ -101,6 +102,12 @@ class Scheduler(RedBase):
         return sorted(tasks, key=lambda task: getattr(task, "priority", 0), reverse=True)
 
     def __call__(self):
+        return self.run()
+
+    def run(self):
+        return asyncio.run(self.serve())
+
+    async def serve(self):
         """Start and run the scheduler. Will block till the end of the scheduling
         session."""
         # Unsetting some flags
@@ -111,7 +118,7 @@ class Scheduler(RedBase):
         self.is_alive = True
         exception = None
         try:
-            self.startup()
+            await self.startup()
 
             while not self.check_shut_cond(self.session.config.shut_cond):
                 if self._flag_shutdown.is_set():
@@ -119,8 +126,8 @@ class Scheduler(RedBase):
                 elif self._flag_restart.is_set():
                     raise SchedulerRestart()
 
-                self._hibernate()
-                self.run_cycle()
+                await self._hibernate()
+                await self.run_cycle()
 
                 # self.maintain()
         except SystemExit as exc:
@@ -146,9 +153,9 @@ class Scheduler(RedBase):
         else:
             self.logger.info('Purpose completed. Shutting down...', extra={"action": "shutdown"})
         finally:
-            self.shut_down(exception=exception)
+            await self.shut_down(exception=exception)
 
-    def run_cycle(self):
+    async def run_cycle(self):
         """Run one round of tasks.
         
         Each task is inspected and in case their starting condition
@@ -173,15 +180,15 @@ class Scheduler(RedBase):
                     pass
                 elif self._flag_enabled.is_set() and self.is_task_runnable(task):
                     # Run the actual task
-                    self.run_task(task)
+                    await self.run_task(task)
                     # Reset force_run as a run has forced
                     task.force_run = False
                 elif self.is_timeouted(task):
                     # Terminate the task
-                    self.terminate_task(task, reason="timeout")
+                    await self.terminate_task(task, reason="timeout")
                 elif self.is_out_of_condition(task):
                     # Terminate the task
-                    self.terminate_task(task)
+                    await self.terminate_task(task)
 
         # Running hooks
         hooker.postrun()
@@ -202,12 +209,12 @@ class Scheduler(RedBase):
                 raise
             return False
 
-    def run_task(self, task:Task, *args, **kwargs):
+    async def run_task(self, task:Task, *args, **kwargs):
         """Run a given task"""
         start_time = datetime.datetime.fromtimestamp(time.time())
 
         try:
-            task(log_queue=self._log_queue)
+            await task.start_async(log_queue=self._log_queue)
         except (SchedulerRestart, SchedulerExit) as exc:
             raise 
         except Exception as exc:
@@ -217,13 +224,13 @@ class Scheduler(RedBase):
             exception = None
             status = "success"
 
-    def terminate_all(self, reason:str=None):
+    async def terminate_all(self, reason:str=None):
         """Terminate all running tasks."""
         for task in self.tasks:
             if task.is_alive():
-                self.terminate_task(task, reason=reason)
+                await self.terminate_task(task, reason=reason)
 
-    def terminate_task(self, task, reason=None):
+    async def terminate_task(self, task, reason=None):
         """Terminate a given task."""
         self.logger.debug(f"Terminating task '{task.name}'")
         is_threaded = hasattr(task, "_thread")
@@ -242,6 +249,12 @@ class Scheduler(RedBase):
 
             # Resetting attr force_termination
             task.force_termination = False
+        elif task.is_alive_as_async():
+            task._async_task.cancel()
+            try:
+                await task._async_task
+            except asyncio.CancelledError:
+                task.log_termination()
         else:
             # The process/thread probably just died after the check
             pass
@@ -281,6 +294,9 @@ class Scheduler(RedBase):
         elif execution == "main":
             return is_condition
         elif execution == "thread":
+            is_not_running = not task.is_alive()
+            return is_not_running and is_condition
+        elif execution == "async":
             is_not_running = not task.is_alive()
             return is_not_running and is_condition
         else:
@@ -336,13 +352,13 @@ class Scheduler(RedBase):
                 
                 task.log_record(record)
 
-    def _hibernate(self):
+    async def _hibernate(self):
         """Go to sleep and wake up when next task can be executed."""
         delay = self.session.config.cycle_sleep
         if delay is not None:
-            time.sleep(delay)
+            await asyncio.sleep(delay)
 
-    def startup(self):
+    async def startup(self):
         """Start up the scheduler.
         
         Starting up includes setting up attributes and
@@ -363,7 +379,7 @@ class Scheduler(RedBase):
                     task.force_run = True
 
                 if self.is_task_runnable(task):
-                    self.run_task(task)
+                    await self.run_task(task)
 
         hooker.postrun()
         self.logger.info(f"Setup complete.")
@@ -378,7 +394,7 @@ class Scheduler(RedBase):
         """Count of tasks that are alive."""
         return sum(task.is_alive() for task in self.tasks)
         
-    def _shut_down_tasks(self, traceback=None, exception=None):
+    async def _shut_down_tasks(self, traceback=None, exception=None):
         non_fatal_excs = (SchedulerRestart,) # Exceptions that are allowed to have graceful exit
         wait_for_finish = not self.session.config.instant_shutdown and (exception is None or isinstance(exception, non_fatal_excs))
         if wait_for_finish:
@@ -386,32 +402,35 @@ class Scheduler(RedBase):
                 # Gracefully shut down (allow remaining tasks to finish)
                 while self.n_alive:
                     #time.sleep(self.min_sleep)
+
+                    await self._hibernate() # This is the time async tasks can continue
+
                     self.handle_logs()
                     for task in self.tasks:
                         if task.permanent_task:
                             # Would never "finish" anyways
-                            self.terminate_task(task)
+                            await self.terminate_task(task)
                         elif self.is_timeouted(task):
                             # Terminate the task
-                            self.terminate_task(task, reason="timeout")
+                            await self.terminate_task(task, reason="timeout")
                         elif self.is_out_of_condition(task):
                             # Terminate the task
-                            self.terminate_task(task)
+                            await self.terminate_task(task)
             except Exception as exc:
                 # Fuck it, terminate all
-                self._shut_down_tasks(exception=exc)
+                await self._shut_down_tasks(exception=exc)
                 return
             else:
                 self.handle_logs()
         else:
-            self.terminate_all(reason="shutdown")
+            await self.terminate_all(reason="shutdown")
 
     def wait_task_alive(self):
         """Wait till all, especially threading tasks, are finished."""
         while self.n_alive > 0:
             time.sleep(0.005)
 
-    def shut_down(self, traceback=None, exception=None):
+    async def shut_down(self, traceback=None, exception=None):
         """Shut down the scheduler.
         
         Shutting down includes running tasks that have 
@@ -440,10 +459,10 @@ class Scheduler(RedBase):
                     task.force_run = True
 
                 if self.is_task_runnable(task):
-                    self.run_task(task)
+                    await self.run_task(task)
 
         self.logger.info(f"Shutting down tasks...")
-        self._shut_down_tasks(traceback, exception)
+        await self._shut_down_tasks(traceback, exception)
 
         if not self.session.config.instant_shutdown:
             self.wait_task_alive() # Wait till all tasks' threads and processes are dead

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -121,12 +121,12 @@ class Scheduler(RedBase):
             await self.startup()
 
             while not self.check_shut_cond(self.session.config.shut_cond):
+                await self._hibernate()
                 if self._flag_shutdown.is_set():
                     break
                 elif self._flag_restart.is_set():
                     raise SchedulerRestart()
 
-                await self._hibernate()
                 await self.run_cycle()
 
                 # self.maintain()

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -476,7 +476,7 @@ class Task(RedBase, BaseModel):
             status = "inaction"
             exc_info = sys.exc_info()
             
-        except TaskTerminationException:
+        except (TaskTerminationException, asyncio.CancelledError):
             # Task was terminated and the task's function
             # did listen to that.
             self.log_termination()

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -234,6 +234,8 @@ class Task(RedBase, BaseModel):
     def parse_timeout(cls, value, values):
         if value == "never":
             return datetime.timedelta.max
+        elif isinstance(value, (float, int)):
+            return to_timedelta(value, unit="s")
         elif value is not None:
             return to_timedelta(value)
         else:

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -67,12 +67,12 @@ class Config(BaseModel):
             return AlwaysFalse()
         return parse_condition(value)
 
-    @validator('timeout')
+    @validator('timeout', pre=True, always=True)
     def parse_timeout(cls, value):
         if isinstance(value, str):
-            return to_timedelta(value).to_pytimedelta()
+            return to_timedelta(value)
         elif isinstance(value, (float, int)):
-            return datetime.timedelta(milliseconds=value * 1000)
+            return datetime.timedelta(seconds=value)
         else:
             return value
 

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -209,6 +209,14 @@ class Session(RedBase):
         self._check_readable_logger()
         self.scheduler()
 
+    async def serve(self):
+        """Start the scheduling session using async.
+
+        Will block and wait till the scheduler finishes 
+        if there is a shut condition."""
+        self._check_readable_logger()
+        await self.scheduler.serve()
+
     def run(self, *task_names:Tuple[str], execution=None, obey_cond=False):
         """Run specific task(s) manually.
 

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -220,10 +220,15 @@ class FuncTask(Task):
         if self.description is None and hasattr(self.func, "__doc__"):
             self.description = self.func.__doc__
 
-    def execute(self, **params):
+    async def execute(self, **params):
         "Run the actual, given, task"
         func = self.get_func(cache=self.cache)
-        output = func(**params)
+
+        is_async = inspect.iscoroutinefunction(func)
+        if is_async:
+            output = await func(**params)
+        else:
+            output = func(**params)
         return output
 
     def get_func(self, cache=True):

--- a/rocketry/test/app/test_app.py
+++ b/rocketry/test/app/test_app.py
@@ -1,4 +1,5 @@
 
+import asyncio
 import logging
 
 from rocketry import Rocketry
@@ -67,6 +68,25 @@ def test_app_tasks():
     assert isinstance(app.session['do_script'], FuncTask)
 
     assert app.session['do_never'].start_cond == false
+
+def test_app_async():
+    set_logging_defaults()
+
+    app = Rocketry(config={'task_execution': 'main'})
+
+    # Creating some tasks
+    @app.task()
+    def do_never():
+        ...
+
+    @app.task('daily')
+    def do_func():
+        ...
+        return 'return value'
+
+    app.session.config.shut_cond = TaskStarted(task='do_func')
+    asyncio.run(app.serve())
+    assert 1 == app.session[do_func].logger.filter_by(action="success").count()
 
 def test_app_run():
     set_logging_defaults()

--- a/rocketry/test/schedule/test_core.py
+++ b/rocketry/test/schedule/test_core.py
@@ -31,13 +31,13 @@ def run_succeeding():
 def run_inacting():
     raise TaskInactionException()
 
-def run_failing_async():
+async def run_failing_async():
     raise RuntimeError("Task failed")
 
-def run_succeeding_async():
+async def run_succeeding_async():
     pass
 
-def run_inacting_async():
+async def run_inacting_async():
     raise TaskInactionException()
 
 

--- a/rocketry/test/schedule/test_methods.py
+++ b/rocketry/test/schedule/test_methods.py
@@ -53,7 +53,8 @@ def test_run_task(execution, task_func, run_count, fail_count, success_count, se
     asyncio.run(scheduler.run_task(task))
     assert run_count == logger.filter_by(action="run").count()
 
-    scheduler.wait_task_alive()
+    while scheduler.n_alive > 0:
+        time.sleep(0.001)
     scheduler.handle_logs()
 
     assert success_count == logger.filter_by(action="success").count()

--- a/rocketry/test/schedule/test_methods.py
+++ b/rocketry/test/schedule/test_methods.py
@@ -5,6 +5,7 @@ only some parts of the scheduler (like
 executing one task)
 """
 
+import asyncio
 import time
 
 import pytest
@@ -49,7 +50,7 @@ def test_run_task(execution, task_func, run_count, fail_count, success_count, se
     logger = task.logger
 
     scheduler = Scheduler(session=session)
-    scheduler.run_task(task)
+    asyncio.run(scheduler.run_task(task))
     assert run_count == logger.filter_by(action="run").count()
 
     scheduler.wait_task_alive()

--- a/rocketry/test/schedule/test_terminate.py
+++ b/rocketry/test/schedule/test_terminate.py
@@ -41,7 +41,7 @@ def get_slow_func(execution):
         "thread": run_slow_threaded,
     }[execution]
 
-@pytest.mark.parametrize("execution", ["aynsc", "thread", "process"])
+@pytest.mark.parametrize("execution", ["async", "thread", "process"])
 def test_without_timeout(tmpdir, execution, session):
     """Test the task.timeout is respected overt scheduler.timeout"""
     # TODO: There is probably better ways to test this

--- a/rocketry/test/session/test_construct.py
+++ b/rocketry/test/session/test_construct.py
@@ -34,3 +34,13 @@ def test_empty():
 
     assert session.env is None
     assert_default(session)
+
+def test_timeout_parse():
+    session = Session(config={"timeout": 0.1})
+    assert session.config.timeout == datetime.timedelta(seconds=0.1)
+
+    session = Session(config={"timeout": "0.1 seconds"})
+    assert session.config.timeout == datetime.timedelta(seconds=0.1)
+
+    session = Session(config={"timeout": datetime.timedelta(seconds=0.1)})
+    assert session.config.timeout == datetime.timedelta(seconds=0.1)

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -1,4 +1,5 @@
 
+import datetime
 import pickle
 import pytest
 from rocketry.core import Task
@@ -14,6 +15,16 @@ def test_defaults(session):
     assert task.name == "mytest"
     assert isinstance(task.start_cond, AlwaysFalse)
     assert isinstance(task.end_cond, AlwaysFalse)
+
+def test_set_timeout(session):
+    task = DummyTask(timeout="1 hour 20 min", session=session, name="1")
+    assert task.timeout == datetime.timedelta(hours=1, minutes=20)
+
+    task = DummyTask(timeout=datetime.timedelta(hours=1, minutes=20), session=session, name="2")
+    assert task.timeout == datetime.timedelta(hours=1, minutes=20)
+
+    task = DummyTask(timeout=20, session=session, name="3")
+    assert task.timeout == datetime.timedelta(seconds=20)
 
 def test_delete(session):
     task = DummyTask(name="mytest")


### PR DESCRIPTION
This PR adds async support (#28) for the main scheduler but also adds support for parallelizing tasks as async.

For example:

```python
@app.task(execution="async")
async def 
```
Some notes:
- If ``async def ...`` is used with execution as ``main``, the scheduler won't continue until the task is completed
- If the task itself is not using ``async def ...`` but just ``def ...``, the task cannot be parallelized
- The task should release the executor every once in a while so that the scheduler can also do work