### PR TITLE
ENH: session shutdown

### DIFF
--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -285,7 +285,18 @@ class Session(RedBase):
         The shut down is not instantenous and 
         will occur after the scheduler finishes
         checking one cycle of tasks."""
+        warnings.warn((
+            "Session.shutdown is deprecated. " 
+            "Please use Session.shut_down instead"
+        ), DeprecationWarning)
         self.scheduler._flag_shutdown.set()
+
+    def shut_down(self, force=None):
+        """Shut down the scheduler"""
+        force = force if force is not None else self.scheduler._flag_shutdown.is_set()
+        self.scheduler._flag_shutdown.set()
+        if force:
+            self.scheduler._flag_force_exit.set()
 
     def _check_readable_logger(self):
         from rocketry.core.log import TaskAdapter

--- a/rocketry/test/session/test_control.py
+++ b/rocketry/test/session/test_control.py
@@ -1,13 +1,17 @@
 
+import asyncio
+import time
 import pytest
 
 from rocketry.args import Session
 import rocketry
+from rocketry.args.builtin import TerminationFlag
 from rocketry.conditions.scheduler import SchedulerStarted
 from rocketry.conditions import TaskStarted
 from rocketry.core.time.base import TimeDelta
 from rocketry.tasks import FuncTask
 from rocketry.conds import true
+from rocketry.exc import TaskTerminationException
 
 
 @pytest.mark.parametrize("execution", ["main", "thread"])
@@ -18,7 +22,7 @@ def test_shutdown(execution, session):
         timeline.append("startup")
 
     def call_shutdown(session:rocketry.Session=Session()):
-        session.shutdown()
+        session.shut_down()
         timeline.append("shutdown-called")
 
     def on_shutdown():
@@ -34,6 +38,45 @@ def test_shutdown(execution, session):
 
     session.start()
     assert timeline == ['startup', 'shutdown-called', 'shutdown']
+
+@pytest.mark.parametrize("doublecall", [False, True])
+@pytest.mark.parametrize("execution", ["async", "thread"])
+def test_shutdown_force(execution, session, doublecall):
+    timeline = []
+
+    def on_startup():
+        timeline.append("startup")
+
+    async def slow_task_async():
+        await asyncio.sleep(2)
+
+    def slow_task_thread(flag=TerminationFlag()):
+        while not flag.is_set():
+            time.sleep(0.001)
+        if flag.is_set():
+            raise TaskTerminationException()
+
+    def call_shutdown(session:rocketry.Session=Session()):
+        if doublecall:
+            session.shut_down()
+            session.shut_down()
+        else:
+            session.shut_down(force=True)
+        timeline.append("shutdown-called")
+
+    slow_func = {'async': slow_task_async, 'thread': slow_task_thread}[execution]
+
+    FuncTask(on_startup, name="startup", on_startup=True, start_cond=true, execution=execution, session=session)
+    task = FuncTask(slow_func, name="slow-task", start_cond=true, execution=execution, session=session)
+    FuncTask(call_shutdown, name="call-shutdown", start_cond=true, execution=execution, session=session)
+    #FuncTask(on_shutdown, name="shutdown", on_shutdown=True, start_cond=true, execution=execution, session=session)
+
+
+    session.config.shut_cond = TaskStarted(task="call-shutdown") >= 3
+
+    session.start()
+    assert timeline == ['startup', 'shutdown-called']
+    assert 1 == task.logger.filter_by(action="terminate").count()
 
 @pytest.mark.parametrize("execution", ["main", "thread"])
 def test_restart(execution, session):

--- a/rocketry/test/session/test_deprecate.py
+++ b/rocketry/test/session/test_deprecate.py
@@ -1,0 +1,13 @@
+
+import logging
+
+import pytest
+from rocketry.core.log.adapter import TaskAdapter
+from rocketry.tasks import FuncTask
+from rocketry.core import Parameters, Scheduler
+
+def test_shutdown(session):
+    assert not session.scheduler._flag_shutdown.is_set()
+    with pytest.warns(DeprecationWarning):
+        session.shutdown()
+    assert session.scheduler._flag_shutdown.is_set()


### PR DESCRIPTION
Renamed ``session.shutdown`` to ``session.shut_down`` and added ``force`` option. Force will terminate all running tasks during shutdown.

Also, if called twice, the force is set.