### PR TITLE
fix typo in docs/index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@
    <hr>
 
 - `Documentation <https://rocketry.readthedocs.io/>`_
-- `Source code (Gitbub) <https://github.com/Miksus/rocketry>`_
+- `Source code (Github) <https://github.com/Miksus/rocketry>`_
 - `Releases (PyPI) <https://pypi.org/project/rocketry/>`_
 
 No time to read? :ref:`Get started then. <getting-started>`


### PR DESCRIPTION
Fixed typo in label of url to github in docs/index.rst