### PR TITLE
ENH: Add AT to hourly, daily, weekly etc.

### DIFF
--- a/docs/code/conds/api/periodical_restricted.py
+++ b/docs/code/conds/api/periodical_restricted.py
@@ -1,25 +1,25 @@
 from rocketry.conds import minutely, hourly, daily, weekly, monthly
 
 @app.task(minutely.before("45"))
-def do_minutely():
+def do_before():
     ...
 
 @app.task(hourly.after("45:00"))
-def do_hourly():
+def do_after():
     ...
 
 @app.task(daily.between("08:00", "14:00"))
-def do_daily():
+def do_between():
     ...
 
 @app.task(daily.at("11:00"))
-def do_weekly():
+def do_at():
     ...
 
 @app.task(weekly.on("Monday"))
-def do_weekly():
+def do_on():
     ...
 
 @app.task(monthly.starting("3rd"))
-def do_monthly():
+def do_starting():
     ...

--- a/docs/code/conds/api/periodical_restricted.py
+++ b/docs/code/conds/api/periodical_restricted.py
@@ -12,6 +12,10 @@ def do_hourly():
 def do_daily():
     ...
 
+@app.task(daily.at("11:00"))
+def do_weekly():
+    ...
+
 @app.task(weekly.on("Monday"))
 def do_weekly():
     ...

--- a/docs/handbooks/conditions/api/periodical.rst
+++ b/docs/handbooks/conditions/api/periodical.rst
@@ -68,12 +68,15 @@ and some illustations what this means for a week/weekly:
 - *after Friday*: From Friday 00:00 (0 am) to Sunday 24:00 (12 pm)
 - *between Tuesday and Friday*: From Tuesday 00:00 (0 am) to Friday 24:00 (12 pm)
 
-There are also *on* and *starting* arguments:
+There are also *on/at* and *starting* methods:
 
-- ``on``: On given time component 
+- ``on/at``: On a given subunit of the period. The method ``on`` is an alias for ``at``.
 - ``starting``: The fixed period starts on given time 
 
-For example, *on Friday* means Friday 00:00 (0 am) to Friday 24:00 (12 pm)
+The subunit of a day is hour, the subunit of a week is day of week, subunit of a 
+month is a day of month etc. To illustrate these options, 
+*on Friday* means Friday 00:00 (0 am) to Tuesday 00:00,
+*at 11:00 (daily)* means from 11:00 to 12:00
 and *starting Friday* means the week is set to start on Friday.
 
 .. literalinclude:: /code/conds/api/periodical_restricted.py

--- a/rocketry/conditions/api.py
+++ b/rocketry/conditions/api.py
@@ -38,6 +38,11 @@ class TimeCondWrapper(BaseCondition):
         return self._get_cond(period)
 
     def on(self, span):
+        # Alias for "at"
+        return self.at(span)
+
+    def at(self, span):
+        # Alias for "on"
         period = self._cls_period(span, time_point=True)
         return self._get_cond(period)
 

--- a/rocketry/test/condition/test_api.py
+++ b/rocketry/test/condition/test_api.py
@@ -65,6 +65,7 @@ params_task_exec = [
     pytest.param(daily.between("10:00", "12:00"), TaskExecutable(period=TimeOfDay("10:00", "12:00")), id="daily between"),
 
     pytest.param(weekly.on("Monday"), TaskExecutable(period=TimeOfWeek("Monday", time_point=True)), id="weekly on"),
+    pytest.param(daily.at("10:00"), TaskExecutable(period=TimeOfDay("10:00", "11:00")), id="daily at"),
 
     pytest.param(monthly.on("1st"), TaskExecutable(period=TimeOfMonth("1st", time_point=True)), id="monthly on"),
 ]


### PR DESCRIPTION
This PR adds ``.at(span)`` to the cond API's time-related conditions:

```python
from rocketry.conds import daily

@app.task(daily.at("11:00"))
def do_things():
    ...
```
Note that the above is same as ``daily.between("11:00", "12:00")`` as the definition is that ``at`` is a span of one subunit of the time period. ``weekly.at("Monday")`` is not proper English but It's the responsibility of the user to learn English.