### PR TITLE
REF: Change default task_execution to async

### DIFF
--- a/docs/handbooks/config.rst
+++ b/docs/handbooks/config.rst
@@ -43,9 +43,10 @@ Options
 
     Options: 
 
-    - process: on separate process (default)
-    - thread: on separate thread
-    - main: no parallelization
+    - ``main``: no parallelization
+    - ``async``: run async if can (default in the future)
+    - ``thread``: on separate thread
+    - ``process``: on separate process (default)
 
 **task_pre_exist**: What happens if a task with given name already exists. 
 

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -44,7 +44,7 @@ class Config(BaseModel):
     # Fields
     use_instance_naming: bool = False
     task_priority: int = 0
-    task_execution: str = 'process'
+    task_execution: Optional[str] = None
     task_pre_exist: str = 'raise'
     force_status_from_logs: bool = False # Force to check status from logs every time (slow but robust)
     
@@ -66,6 +66,18 @@ class Config(BaseModel):
     shut_cond: Optional['BaseCondition'] = None
 
     param_materialize:Literal['pre', 'post'] = 'post'
+
+    @validator('task_execution', pre=True, always=True)
+    def parse_task_execution(cls, value):
+        if value is None:
+            warnings.warn(
+                "Default execution will be changed to 'async'. "
+                "To suppress this warning, specify task_execution, "
+                "ie. Rocketry(task_execution='async')", 
+                FutureWarning
+            )
+            return 'process'
+        return value
 
     @validator('shut_cond', pre=True)
     def parse_shut_cond(cls, value):

--- a/rocketry/test/session/test_deprecate.py
+++ b/rocketry/test/session/test_deprecate.py
@@ -1,5 +1,6 @@
 
 import logging
+import warnings
 
 import pytest
 from rocketry.core.log.adapter import TaskAdapter
@@ -12,3 +13,17 @@ def test_shutdown(session):
     with pytest.warns(DeprecationWarning):
         session.shutdown()
     assert session.scheduler._flag_shutdown.is_set()
+
+def test_no_execution_method():
+
+    with pytest.warns(FutureWarning):
+        Session()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        # Test the following won't warn
+        Session(config=dict(task_execution="process"))
+        Session(config=dict(task_execution="thread"))
+        Session(config=dict(task_execution="main"))
+        Session(config=dict(task_execution="async"))


### PR DESCRIPTION
It has caused confusion that ``process`` is the default task execution type. This PR warns if execution type is not set so that after the next release the default can be changed to ``async``.