### PR TITLE
ENH: Multiple values to at/on in cond API

### DIFF
--- a/docs/code/conds/api/periodical_restricted.py
+++ b/docs/code/conds/api/periodical_restricted.py
@@ -16,8 +16,16 @@ def do_between():
 def do_at():
     ...
 
+@app.task(daily.at("08:00", "12:00", "18:00"))
+def do_at_multiple():
+    ...
+
 @app.task(weekly.on("Monday"))
 def do_on():
+    ...
+
+@app.task(weekly.on("Monday", "Friday", "Sunday"))
+def do_on_multiple():
     ...
 
 @app.task(monthly.starting("3rd"))

--- a/docs/handbooks/conditions/api/periodical.rst
+++ b/docs/handbooks/conditions/api/periodical.rst
@@ -88,6 +88,13 @@ and *starting Friday* means the week is set to start on Friday.
     ``between Monday and Friday`` means Monday at 00:00
     (0 am) to Friday 24:00 (12 pm).
 
+.. note::
+
+    Passing multiple values to *at/on* is a convenient way to schedule
+    a task to run at multiple times. For example, ``weekly.on("Mon", "Fri")`` 
+    is the same as ``weekly.on("Mon") | weekly.on("Fri")`` and it can be used
+    to run a task on Mondays and Fridays.
+
 There are also **time of ...** conditions check if the current time
 is within the given period.
 

--- a/rocketry/test/condition/test_api.py
+++ b/rocketry/test/condition/test_api.py
@@ -82,6 +82,8 @@ params_task_exec = [
 
     pytest.param(daily.at("23:00:00"), TaskExecutable(period=TimeOfDay("23:00:00", "00:00:00")), id="daily at end"),
     pytest.param(daily.at("23:00:01"), TaskExecutable(period=TimeOfDay("23:00:01", "00:00:01")), id="daily at specific"),
+
+    pytest.param(weekly.at("Mon", "Wed", "Fri"), TaskExecutable(period=TimeOfWeek("Monday", time_point=True)) | TaskExecutable(period=TimeOfWeek("Wednesday", time_point=True)) | TaskExecutable(period=TimeOfWeek("Friday", time_point=True)), id="weekly at (multiple)"),
 ]
 
 params_pipeline = [
@@ -165,3 +167,5 @@ def test_observe(cond, session):
 def test_fail():
     with pytest.raises(ValueError):
         every("5 seconds", based="oops")
+    with pytest.raises(TypeError):
+        daily.at()


### PR DESCRIPTION
This PR makes this possible:
```python
from rocketry.conds import daily, weekly

@app.task(daily.at("12:00", "18:00"))
def do_daily_twice():
    ... # Condition translates to: daily.at("12:00") | daily.at("18:00")

@app.task(weekly.on("Mon", "Fri"))
def do_weekly_twice():
    ... # Condition translates to: weekly.on("Mon") | weekly.on("Fri")
```