### PR TITLE
Fix using the default session while removing a task

### DIFF
--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -397,7 +397,7 @@ class Session(RedBase):
     def remove_task(self, task: Union['Task', str]):
         if isinstance(task, str):
             task = self[task]
-        self.session.tasks.remove(task)
+        self.tasks.remove(task)
 
     def task_exists(self, task: 'Task'):
         warnings.warn((

--- a/rocketry/test/conftest.py
+++ b/rocketry/test/conftest.py
@@ -80,7 +80,7 @@ def session():
         "task_execution": "process",
     }, delete_existing_loggers=True)
     rocketry.session = session
-    session.set_as_default()
+    # session.set_as_default()
 
     task_logger = logging.getLogger(session.config.task_logger_basename)
     task_logger.handlers = [


### PR DESCRIPTION
As discussed in #130, here is the fix. I removed the set session as default, so the test `test_remove` stopped passing. Finally, I changed the function `remove_task` to not use the default session.