### PR TITLE
add __str__ to TaskRunnable in conds

### DIFF
--- a/rocketry/conditions/api.py
+++ b/rocketry/conditions/api.py
@@ -71,6 +71,12 @@ class TimeCondWrapper(BaseCondition):
     def _get_cond(self, period):
         return self._cls_cond(period=period, **self._cond_kwargs)
 
+    def __str__(self):
+        try:
+            return BaseCondition.__str__(self)
+        except AttributeError:
+            return str(self.get_cond())
+
 class TimeActionWrapper(BaseCondition):
 
     def __init__(self, cls_cond, task=None):

--- a/rocketry/conditions/task/task.py
+++ b/rocketry/conditions/task/task.py
@@ -360,6 +360,15 @@ class TaskRunnable(BaseCondition):
             and has_not_run.observe(task=task, session=session)
         )
 
+    def __str__(self):
+        if hasattr(self, "_str"):
+            return self._str
+        period = self.period
+        task = self.task
+        task_name = getattr(task, "name", str(task))
+        period = "" if period is None else f" {period}"
+        return f"task '{task_name}' runnable{period}"
+
 
 class DependFinish(DependMixin):
     """Condition for checking whether a given

--- a/rocketry/test/condition/test_parse.py
+++ b/rocketry/test/condition/test_parse.py
@@ -201,6 +201,15 @@ def test_back_to_string(cond_str, expected):
     assert cond == cond_2
     #assert cond_str == cond_as_str
 
+# Cases with tasks children
+extended_cases_tasks =  cron + cases_task + cases_time
+@pytest.mark.parametrize(
+    "cond_str,task", extended_cases_tasks
+)
+def test_task_to_str(cond_str, task):
+    task_as_str = str(task)
+    assert len(task_as_str) > 0
+
 @pytest.mark.parametrize("cond_str,exc",
     [
         pytest.param("this is not valid", ParserError, id="Invalid condition"),


### PR DESCRIPTION
This pull request adds __str__ method to TaskRunnable, found in rocketry.conditions.task.task.TaskRunnable.
By adding __str__ method to TaskRunnable, we solve issue of AttributeError in issue (to be updated: I will create an issue) and let cast TaskRunnable to string.

