### PR TITLE
BUG: Cache before startup

### DIFF
--- a/docs/cookbook/settings.rst
+++ b/docs/cookbook/settings.rst
@@ -63,6 +63,22 @@ are in production or test:
             config.silence_task_logging = False
             config.silence_cond_check = False
 
+.. note::
+
+    The tasks' caches (ie. status and last run/success/fail) are set after the 
+    hooks have run. If your setup needs to run after the caches are set
+    and startup tasks have run, you can do it by:
+
+    .. code-block:: python
+
+        @app.setup()
+        def setup_app():
+            # Run before startup tasks and cache is set
+            ...
+            yield
+            # Run after startup tasks and cache is set
+            ...
+
 You can also modify tasks in the setup. For example,
 if you wish to have an environment to test only the
 scheduling (without running anything):

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -11,6 +11,7 @@ Version history
         runs can be tracked in the logs using the field ``run_id``.
 
     - Update: ``rocketry.conds.running`` refactored to support multi-launch.
+    - Update: Task cache is no longer set at initiation but at session start
     - Add: New config option ``timezone``
     - Add: New config option ``time_func`` for testing scheduling
     - API: Added config option ``execution`` (deprecated ``task_execution``)

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -309,6 +309,7 @@ class Scheduler(RedBase):
 
         self.logger.debug("Beginning startup sequence...")
         for task in self.tasks:
+            task.set_cached()
             if task.on_startup:
                 if isinstance(task.start_cond, AlwaysFalse) and not task.disabled:
                     # Make sure the tasks run if start_cond not set

--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -309,7 +309,13 @@ class Scheduler(RedBase):
 
         self.logger.debug("Beginning startup sequence...")
         for task in self.tasks:
-            task.set_cached()
+            try:
+                task.set_cached()
+            except TaskLoggingError:
+                self.logger.exception(f"Failed setting cache for task '{task.name}'")
+                if not self.session.config.silence_task_logging:
+                    raise
+            
             if task.on_startup:
                 if isinstance(task.start_cond, AlwaysFalse) and not task.disabled:
                     # Make sure the tasks run if start_cond not set

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -327,9 +327,6 @@ class Task(RedBase, BaseModel):
 
         self.register()
 
-        # Update "last_run", "last_success", etc.
-        self.set_cached()
-
         # Hooks
         hooker.postrun()
 
@@ -1248,7 +1245,7 @@ class Task(RedBase, BaseModel):
 
 
         if allow_cache: #  and getattr(self, cache_attr) is not None
-            value = getattr(self, cache_attr)
+            value = getattr(self, cache_attr, None)
         else:
             value = self._get_last_action_from_log(action, logger)
             setattr(self, cache_attr, value)

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -326,7 +326,8 @@ class Task(RedBase, BaseModel):
         self.session._check_readable_logger()
 
         self.register()
-
+        self._init_cache()
+        
         # Hooks
         hooker.postrun()
 
@@ -904,6 +905,14 @@ class Task(RedBase, BaseModel):
             return # on_exists = 'ignore'
         name = self.name
         self.session.add_task(self)
+
+    def _init_cache(self):
+        self._last_run = None
+        self._last_success = None
+        self._last_fail = None
+        self._last_terminate = None
+        self._last_inaction = None
+        self._last_crash = None
 
     def set_cached(self):
         "Update cached statuses"

--- a/rocketry/test/app/test_hooks.py
+++ b/rocketry/test/app/test_hooks.py
@@ -82,6 +82,9 @@ def test_setup_cache():
     assert task.status is None
     assert task._last_run is None
     assert task._last_success is None
+    assert task._last_fail is None
+    assert task._last_inaction is None
+    assert task._last_crash is None
 
     app.session.config.shut_cond = true
     app.run()

--- a/rocketry/test/task/func/test_logging.py
+++ b/rocketry/test/task/func/test_logging.py
@@ -10,6 +10,7 @@ from redbird.logging import RepoHandler
 from rocketry.log.log_record import  MinimalRecord
 from rocketry.tasks import FuncTask
 from rocketry.testing.log import create_task_record
+from rocketry.conds import true
 
 def run_success():
     pass
@@ -55,6 +56,7 @@ def test_set_cached_in_init(session, optimized, last_status):
         name="mytask",
         session=session
     )
+    task.set_cached()
     for action, created in times.items():
         dt = datetime.datetime.fromtimestamp(created)
         last_action_value = getattr(task, f"last_{action}")
@@ -204,10 +206,11 @@ def test_without_handlers_status_warnings(session):
             session=session
         )
     # Removing the handlers that were added
-
+    session.config.shut_cond = true
+    with pytest.warns(UserWarning) as warns:
+        session.start()
     # Test warnings
     expected_warnings = [
-        'Logger rocketry.task cannot be read. Logging is set to memory. To supress this warning, please set a handler that can be read (redbird.logging.RepoHandler)',
         "Logger 'rocketry.task.test' for task 'task 1' does not have ability to be read. Past history of the task cannot be utilized.",
         "Task 'task 1' logger is not readable. Latest run unknown.",
         "Task 'task 1' logger is not readable. Latest success unknown.",

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -76,6 +76,7 @@ def test_pickle(session):
 
 def test_crash(session):
     task = DummyTask(name="mytest", session=session)
+    task.set_cached()
     task.log_running()
     assert task.status == "run"
     assert task.last_crash is None
@@ -83,6 +84,7 @@ def test_crash(session):
 
     # Recreating and now should log crash
     task = DummyTask(name="mytest", session=session)
+    task.set_cached()
     assert task.status == "crash"
     assert task.last_crash
 
@@ -105,6 +107,7 @@ def test_json(session):
         "task": Task(),
         "another_task": Task('another')
     }, session=session)
+    task.set_cached()
     j = task.json(indent=4)
 
     dt_run = datetime.datetime.fromtimestamp(1640988000)


### PR DESCRIPTION
This PR fixes the issue with incorrect cache if repo is changed with ``app.startup``.

Also, the cache init is now at session start and not at the task init.