### PR TITLE
ENH: Add SchedulerLogger

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -14,6 +14,7 @@ Version history
     - Update: Task cache is no longer set at initiation but at session start
     - Add: New config option ``timezone``
     - Add: New config option ``time_func`` for testing scheduling
+    - Add: New arguments, ``TaskLogger`` and ``SchedulerLogger``
     - API: Added config option ``execution`` (deprecated ``task_execution``)
     - API: Added task argument ``permanent`` (deprecated ``permanent_task``)
     - Meta: Changed build from setup.py to pyproject.toml

--- a/rocketry/args/__init__.py
+++ b/rocketry/args/__init__.py
@@ -1,3 +1,3 @@
 
-from .builtin import Arg, FuncArg, Return, Session, Config, Task, TaskLogger, TerminationFlag, SimpleArg, EnvArg, CliArg, argument
+from .builtin import Arg, FuncArg, Return, Session, Config, Task, TaskLogger, SchedulerLogger, TerminationFlag, SimpleArg, EnvArg, CliArg, argument
 from .secret import Private

--- a/rocketry/args/builtin.py
+++ b/rocketry/args/builtin.py
@@ -126,6 +126,13 @@ class TaskLogger(BaseArgument):
         task_logger = logging.getLogger(logger_name)
         return TaskAdapter(task_logger, task=task)
 
+class SchedulerLogger(BaseArgument):
+    "Argument that represents the scheduler logger"
+
+    def get_value(self, session=Session(default=None), **kwargs) -> Any:
+        logger_name = session.config.scheduler_logger_basename if session is not None else 'rocketry.scheduler'
+        return logging.getLogger(logger_name)
+
 class Return(BaseArgument):
     """A return argument
 

--- a/rocketry/test/args/test_args.py
+++ b/rocketry/test/args/test_args.py
@@ -1,7 +1,8 @@
 import os
 import sys
+from build import logging
 import pytest
-from rocketry.args import Private, SimpleArg, FuncArg, Arg, EnvArg, CliArg, Return, TerminationFlag, Task, Session, TaskLogger, Config
+from rocketry.args import Private, SimpleArg, FuncArg, Arg, EnvArg, CliArg, Return, TerminationFlag, Task, Session, TaskLogger, SchedulerLogger, Config
 from rocketry.core.log.adapter import TaskAdapter
 from rocketry.core.parameters.parameters import Parameters
 from rocketry.tasks import FuncTask
@@ -147,6 +148,11 @@ def test_task_logger(session):
 
     p = Parameters(logger=TaskLogger())
     assert isinstance(p.materialize(session=session)['logger'], TaskAdapter)
+
+def test_scheduler_logger(session):
+    logger = SchedulerLogger().get_value(session=session)
+    assert logger.name == "rocketry.scheduler"
+    assert isinstance(logger, logging.Logger)
 
 # Magic
 # -----

--- a/rocketry/test/args/test_args.py
+++ b/rocketry/test/args/test_args.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from build import logging
+import logging
 import pytest
 from rocketry.args import Private, SimpleArg, FuncArg, Arg, EnvArg, CliArg, Return, TerminationFlag, Task, Session, TaskLogger, SchedulerLogger, Config
 from rocketry.core.log.adapter import TaskAdapter


### PR DESCRIPTION
``SchedulerLogger`` is to ``TaskLogger``:

```python
from rocketry.args import TaskLogger, SchedulerLogger
@app.setup()
def setup_app(task_logger=TaskLogger(), sched_logger=SchedulerLogger()):
    sched_logger.addHandler(...)
```