### PR TITLE
BUG: Fix multilaunch spam

### DIFF
--- a/rocketry/core/schedule.py
+++ b/rocketry/core/schedule.py
@@ -173,6 +173,7 @@ class Scheduler(RedBase):
         for task in tasks:
             with task.lock:
                 self.handle_logs()
+                task._clean_run_stack()
                 if task.on_startup or task.on_shutdown:
                     # Startup or shutdown tasks are not run in main sequence
                     pass

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -429,7 +429,6 @@ class Task(RedBase, BaseModel):
     def is_alive(self) -> bool:
         """Whether the task is alive: check if the task has a live process or thread."""
         #! TODO: Use property
-        self._clean_run_stack()
         return any(
             run.is_alive()
             for run in self._run_stack
@@ -992,7 +991,7 @@ class Task(RedBase, BaseModel):
             for run in self._run_stack:
                 start = run.start
                 run_duration = now - start
-                if run_duration > timeout_sec:
+                if run.is_alive() and run_duration > timeout_sec:
                     await self._terminate_run(run, reason="timeouted")
 
     def _clean_run_stack(self):


### PR DESCRIPTION
This should fix the issue with #144.

The issue was caused by that the run stack was never cleaned and the termination check included finished runs. Fixed by cleaning the run stack periodically and also now it should not terminate finished runs.