### PR TITLE
BUG: TaskLogRecord and TaskRunRecord extra fields

### DIFF
--- a/rocketry/log/log_record.py
+++ b/rocketry/log/log_record.py
@@ -2,6 +2,8 @@ import datetime
 from typing import Optional
 from pydantic import BaseModel, Field, validator
 
+from rocketry.pybox.time import to_datetime, to_timedelta
+
 class MinimalRecord(BaseModel):
     """A log record with minimal number of fields for Rocketry to work"""
     task_name: str
@@ -46,19 +48,19 @@ class TaskLogRecord(MinimalRecord):
     @validator("start", pre=True)
     def format_start(cls, value):
         if value is not None:
-            value = datetime.datetime.fromtimestamp(value)
+            value = to_datetime(value)
         return value
 
     @validator("end", pre=True)
     def format_end(cls, value):
         if value is not None:
-            value = datetime.datetime.fromtimestamp(value)
+            value = to_datetime(value)
         return value
 
     @validator("runtime", pre=True)
     def format_runtime(cls, value):
         if value is not None:
-            value = datetime.timedelta(seconds=value)
+            value = to_timedelta(value)
         return value
 
 class MinimalRunRecord(MinimalRecord):

--- a/rocketry/pybox/time/convert.py
+++ b/rocketry/pybox/time/convert.py
@@ -40,6 +40,8 @@ def to_datetime(s, timezone=None):
         dt = s
     elif isinstance(s, str):
         dt = string_to_datetime(s)
+    elif isinstance(s, (int, float)):
+        dt = datetime.datetime.fromtimestamp(s)
     elif hasattr(s, "timestamp"):
         # Is datetime-like. Tests' monkeypatching
         # overrides datetime.datetime thus we cannot

--- a/rocketry/test/log/test_repo.py
+++ b/rocketry/test/log/test_repo.py
@@ -12,13 +12,14 @@ def get_csv(model, tmpdir):
     return CSVFileRepo(filename=str(file), model=model)
 
 def get_sql(model, tmpdir):
+    pytest.importorskip("sqlalchemy")
     return SQLRepo(conn_string="sqlite://", table="mylogs", if_missing="create", model=model, id_field="created")
 
 @pytest.mark.parametrize("get_repo", [get_csv, get_sql])
 @pytest.mark.parametrize("model", [MinimalRecord, MinimalRunRecord, TaskLogRecord, TaskRunRecord])
 def test_cache(session, tmpdir, model, get_repo):
     if get_repo == get_sql and model in (TaskRunRecord, TaskLogRecord) and redbird.version_tuple[:3] <= (0, 6, 0):
-        pytest.skip(reason="Red Bird <=0.6.0 does not support date-like in SQL table creation")
+        pytest.skip(reason="Red Bird <= 0.6.0 does not support date-like in SQL table creation")
     repo = get_repo(model=model, tmpdir=tmpdir)
     task_logger = logging.getLogger(session.config.task_logger_basename)
     task_logger.handlers = [

--- a/rocketry/test/log/test_repo.py
+++ b/rocketry/test/log/test_repo.py
@@ -1,0 +1,41 @@
+import logging
+
+import pytest
+import redbird
+from redbird.logging import RepoHandler
+from redbird.repos import CSVFileRepo, SQLRepo
+from rocketry import Rocketry
+from rocketry.log import MinimalRecord, MinimalRunRecord, TaskLogRecord, TaskRunRecord
+
+def get_csv(model, tmpdir):
+    file = tmpdir.join("logs.csv")
+    return CSVFileRepo(filename=str(file), model=model)
+
+def get_sql(model, tmpdir):
+    return SQLRepo(conn_string="sqlite://", table="mylogs", if_missing="create", model=model, id_field="created")
+
+@pytest.mark.parametrize("get_repo", [get_csv, get_sql])
+@pytest.mark.parametrize("model", [MinimalRecord, MinimalRunRecord, TaskLogRecord, TaskRunRecord])
+def test_cache(session, tmpdir, model, get_repo):
+    if get_repo == get_sql and model in (TaskRunRecord, TaskLogRecord) and redbird.version_tuple[:3] <= (0, 6, 0):
+        pytest.skip(reason="Red Bird <=0.6.0 does not support date-like in SQL table creation")
+    repo = get_repo(model=model, tmpdir=tmpdir)
+    task_logger = logging.getLogger(session.config.task_logger_basename)
+    task_logger.handlers = [
+        RepoHandler(repo=repo),
+        #logging.StreamHandler(sys.stdout)
+    ]
+
+    task = session.create_task(func=lambda: None, name="task 1")
+    task.log_running()
+    task.log_success()
+
+    task.set_cached()
+    
+    logs = repo.filter_by().all()
+    logs = [{"action": r.action, "task_name": r.task_name} for r in logs]
+    assert task.status == "success"
+    assert logs == [
+        {"action": "run", "task_name": "task 1"},
+        {"action": "success", "task_name": "task 1"}
+    ]


### PR DESCRIPTION
This PR fixes the problem with ``TaskLogRecord`` and ``TaskRunRecord``:

```
...
Traceback (most recent call last):
  File "...\lib\site-packages\redbird\base.py", line 321, in data_to_item        
    return self.model(**data)
  File "pydantic\main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for TaskLogRecord
start
  an integer is required (got type str) (type=type_error)
...
```