### PR TITLE
Docs/cookbooks django

### DIFF
--- a/docs/cookbook/django.rst
+++ b/docs/cookbook/django.rst
@@ -194,8 +194,9 @@ and call it after ``application = get_wsgi_application()``:
     init_scheduled_tasks()
 
 Notice that if you are using gunicorn with multiple workers, each worker will create one
-instance of rocketry which will be running all the tasks. This is a undesired behavior
-and needs to be taken care off if you wish to use this kind of integration with django
+process of rocketry which will be running all the tasks. This is aimed primarily towards
+development where you need to restart the server all the time and the server is single
+threaded.
 
 .. note ::
     You will only need to use ``sync_to_async`` if you use the asynchronous ORM. The usage is well documented in

--- a/docs/cookbook/django.rst
+++ b/docs/cookbook/django.rst
@@ -158,7 +158,7 @@ called ``scheduled_tasks.py`` with the tasks referent to that app:
         app.task('every 10 seconds', func=run_do_things_with_user_app_x)
 
 And than, in the same module where the file ``wsgi.py`` is located, add a file called
-``init_scheduled_tasks.py`` (or anywhere you like, just make sure to import the file
+``init_scheduled_tasks.py`` (or anywhere you would like, just make sure to import the file
 correctly), which will import the register functions of each file of tasks and
 initialize rocketry in another process:
 
@@ -180,7 +180,7 @@ initialize rocketry in another process:
         p.start()
 
 After that, go to the ``wsgi.py`` file, import the ``init_scheduled_tasks`` function
-and call it after "``application = get_wsgi_application()``":
+and call it after ``application = get_wsgi_application()``:
 
 .. code-block:: python
 


### PR DESCRIPTION
A way to start rocketry at server start without having to write a command in manage.py for increased development speed. This is aimed primarily towards development environment. 

Maintainers are open to improve this PR in anyway they wish.