### PR TITLE
Add Annotated supporting

### DIFF
--- a/rocketry/test/parameters/test_construct.py
+++ b/rocketry/test/parameters/test_construct.py
@@ -1,7 +1,8 @@
 
 import pytest
+from typing_extensions import Annotated
 import rocketry
-from rocketry.args import FuncArg
+from rocketry.args import FuncArg, SimpleArg
 
 from rocketry.core import Parameters
 from rocketry.args import Private
@@ -76,3 +77,19 @@ def test_func_param_named(session:rocketry.Session):
     assert isinstance(session.parameters._params['a_param'], FuncArg)
     assert session.parameters['a_param'] == 5
     assert session.parameters._params['a_param'].func is my_param
+
+
+def test_annotated():
+    arg = SimpleArg(1)
+
+    def func(arg: Annotated[int, arg]):
+        ...
+    
+    params = Parameters._from_signature(func).materialize()
+    assert params["arg"] == 1
+
+    def func2(arg: Annotated[int, arg, str]):
+        ...
+    
+    with pytest.raises(AssertionError):
+        Parameters._from_signature(func2)


### PR DESCRIPTION
FastAPI and Pydantic supports a new feature: `Annotated`, but **rocketry** still doesn't.
It's a pretty usefull to declare some application-level Arguments and use it everywhere.

Code without `Annotated`:

```python
arg = SimpleArg(1)

@app.task("...")
def func(dep: int = arg):
    ...

@app.task("...")
def func2(dep: int = arg):
    ...
```

Code with `Annotated`

```python
from typing_extensions import Annotated

arg = SimpleArg(1)

ArgDep = Annotated[int, arg]

@app.task("...")
def func(dep: ArgDep):
    ...

@app.task("...")
def func2(dep: ArgDep):
    ...
```

I suppose, all packages, based on function signature, should implement this feature too. So, I am here to make it.