### PR TITLE
Support for PydanticV2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # Coverage
 cov_data/
+
+#Custom
+test.py

--- a/rocketry/_base.py
+++ b/rocketry/_base.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from rocketry import Session
 

--- a/rocketry/_base.py
+++ b/rocketry/_base.py
@@ -5,4 +5,6 @@ if TYPE_CHECKING:
 
 class RedBase:
     """Baseclass for all Rocketry classes"""
-    session: 'Session' = None
+    
+    # Commented this out for now as it was causing issues with the new pydantic implementation
+    # session: 'Session' = None

--- a/rocketry/_base.py
+++ b/rocketry/_base.py
@@ -1,11 +1,12 @@
-from typing import TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Any, ClassVar
+from pydantic.dataclasses import dataclass, Field
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from rocketry import Session
 
-class RedBase:
+class RedBase():
     """Baseclass for all Rocketry classes"""
     
     # Commented this out for now as it was causing issues with the new pydantic implementation
-    # session: 'Session' = None
+    session: 'Session'

--- a/rocketry/_base.py
+++ b/rocketry/_base.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from rocketry import Session
 
-class RedBase():
+class RedBase:
     """Baseclass for all Rocketry classes"""
     
     # Commented this out for now as it was causing issues with the new pydantic implementation

--- a/rocketry/_setup.py
+++ b/rocketry/_setup.py
@@ -3,7 +3,7 @@ from rocketry.core import BaseCondition, Task
 from rocketry.session import Session, Config
 from rocketry.parse import add_condition_parser
 from rocketry.conds import true, false
-from rocketry.tasks import CommandTask, FuncTask, CodeTask
+from rocketry.tasks import CommandTask, FuncTask, CodeTask, _DummyTask
 from rocketry.tasks.maintain import ShutDown, Restart
 
 from rocketry.conditions.meta import _FuncTaskCondWrapper
@@ -23,7 +23,7 @@ def _setup_defaults():
     cls_tasks = (
         Task,
         FuncTask, CommandTask, CodeTask,
-        ShutDown, Restart,
+        ShutDown, Restart, _DummyTask,
 
         _FuncTaskCondWrapper
     )

--- a/rocketry/_setup.py
+++ b/rocketry/_setup.py
@@ -28,9 +28,19 @@ def _setup_defaults():
         _FuncTaskCondWrapper
     )
     for cls_task in cls_tasks:
-        cls_task.update_forward_refs(Session=Session, BaseCondition=BaseCondition)
+        #cls_task.update_forward_refs(Session=Session, BaseCondition=BaseCondition)
+        cls_task.model_rebuild(
+            force=True,
+            _types_namespace={"Session": Session, "BaseCondition": BaseCondition}, 
+            _parent_namespace_depth=4
+            )
 
-    Config.update_forward_refs(BaseCondition=BaseCondition)
+    # Config.update_forward_refs(BaseCondition=BaseCondition)
+    Config.model_rebuild(
+        force=True, 
+        _types_namespace={"Session": Session, "BaseCondition": BaseCondition}, 
+        _parent_namespace_depth=4
+        )
     #Session.update_forward_refs(
     #    Task=Task, Parameters=Parameters, Scheduler=Scheduler
     #)

--- a/rocketry/conditions/meta.py
+++ b/rocketry/conditions/meta.py
@@ -1,6 +1,6 @@
 
 import copy
-from typing import Callable, Optional, Pattern, Union
+from typing import Callable, ClassVar, Optional, Pattern, Union
 
 from pydantic import Field
 from rocketry.args import Session
@@ -13,7 +13,7 @@ from rocketry.tasks.func import FuncTask
 class _FuncTaskCondWrapper(FuncTask):
 
     # For some reason, the order of cls attrs broke here so we need to reorder then:
-    session: _Session
+    session: ClassVar[_Session]
     name: Optional[str] = Field(description="Name of the task. Must be unique")
 
     def _handle_return(self, value):

--- a/rocketry/conditions/meta.py
+++ b/rocketry/conditions/meta.py
@@ -13,7 +13,7 @@ from rocketry.tasks.func import FuncTask
 class _FuncTaskCondWrapper(FuncTask):
 
     # For some reason, the order of cls attrs broke here so we need to reorder then:
-    session: ClassVar[_Session]
+    session: _Session
     name: Optional[str] = Field(description="Name of the task. Must be unique")
 
     def _handle_return(self, value):

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -95,7 +95,7 @@ class TaskRun:
     def is_thread(self) -> bool:
         return isinstance(self.task, threading.Thread)
 
-class Task(RedBase, BaseModel):
+class Task(BaseModel, RedBase):
     """Base class for Tasks.
 
     A task can be a function, command or other procedure that
@@ -200,7 +200,7 @@ class Task(RedBase, BaseModel):
         extra='allow',      
     )
 
-    session: 'Session' = Field()
+    session: 'Session' = Field(validate_default=False, default=None)
 
     # Class
     permanent: bool = False # Whether the task is not meant to finish (Ie. RestAPI)

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -199,7 +199,7 @@ class Task(BaseModel, RedBase):
         extra='allow',      
     )
 
-    session: 'Session' = Field(validate_default=False, default=None)
+    session: 'Session' = Field(default=None)
 
     # Class
     permanent: bool = False # Whether the task is not meant to finish (Ie. RestAPI)

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -743,7 +743,6 @@ class Task(BaseModel, RedBase):
 
         self._run_stack.append(task_run)
         self._mark_running = True # needed in pickling
-
         process.start()
         self._mark_running = False
 
@@ -763,7 +762,6 @@ class Task(BaseModel, RedBase):
         # in the actual multiprocessing's process. We only add QueueHandler to the
         # logger (with multiprocessing.Queue as queue) so that all the logging
         # records end up in the main process to be logged properly.
-
         basename = self.logger_name
         # handler = logging.handlers.QueueHandler(queue)
         handler = QueueHandler(queue)

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -196,7 +196,6 @@ class Task(BaseModel, RedBase):
     model_config = ConfigDict(
         arbitrary_types_allowed= True,
         validate_assignment = True,
-        validate_default=True,
         extra='allow',      
     )
 
@@ -207,7 +206,7 @@ class Task(BaseModel, RedBase):
     _actions: ClassVar[Tuple] = ("run", "fail", "success", "inaction", "terminate", None, "crash")
     fmt_log_message: str = r"Task '{task}' status: '{action}'"
 
-    daemon: Optional[bool] = False
+    daemon: Optional[bool] = None
     batches: List[Parameters] = Field(
         default_factory=list,
         description="Run batches (parameters). If not empty, run is triggered regardless of starting condition"

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -199,7 +199,8 @@ class Task(BaseModel, RedBase):
         extra='allow',      
     )
 
-    session: 'Session' = Field(default=None)
+    session: 'Session' = Field(default=None, validate_default=False)
+    
 
     # Class
     permanent: bool = False # Whether the task is not meant to finish (Ie. RestAPI)
@@ -1415,5 +1416,5 @@ class Task(BaseModel, RedBase):
         if 'exclude' not in kwargs:
             kwargs['exclude'] = set()
         kwargs['exclude'].update({'session'})
-        d = super().json(**kwargs)
+        d = super().model_dump_json(**kwargs)
         return d

--- a/rocketry/core/task.py
+++ b/rocketry/core/task.py
@@ -22,7 +22,6 @@ except ImportError: # pragma: no cover
     from typing_extensions import Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, ConfigDict, field_validator
-from pydantic.functional_validators import BeforeValidator, AfterValidator
 
 from rocketry._base import RedBase
 from rocketry.core.condition import BaseCondition, AlwaysFalse, All

--- a/rocketry/log/log_record.py
+++ b/rocketry/log/log_record.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 
 from rocketry.pybox.time import to_datetime, to_timedelta
 
@@ -38,36 +38,39 @@ class LogRecord(MinimalRecord):
 
 class TaskLogRecord(MinimalRecord):
 
-    start: Optional[datetime.datetime]
-    end: Optional[datetime.datetime]
-    runtime: Optional[datetime.timedelta]
+    start: Optional[datetime.datetime] = None
+    end: Optional[datetime.datetime] = None
+    runtime: Optional[datetime.timedelta] = None
 
     message: str
-    exc_text: Optional[str]
+    exc_text: Optional[str] = None
 
-    @validator("start", pre=True)
+    @field_validator("start", mode="before")
+    @classmethod
     def format_start(cls, value):
         if value is not None:
             value = to_datetime(value)
         return value
 
-    @validator("end", pre=True)
+    @field_validator("end", mode="before")
+    @classmethod
     def format_end(cls, value):
         if value is not None:
             value = to_datetime(value)
         return value
 
-    @validator("runtime", pre=True)
+    @field_validator("runtime", mode="before")
+    @classmethod
     def format_runtime(cls, value):
         if value is not None:
             value = to_timedelta(value)
         return value
 
 class MinimalRunRecord(MinimalRecord):
-    run_id: Optional[str]
+    run_id: Optional[str] = None
 
 class RunRecord(LogRecord):
-    run_id: Optional[str]
+    run_id: Optional[str] = None
 
 class TaskRunRecord(TaskLogRecord):
-    run_id: Optional[str]
+    run_id: Optional[str] = None

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -538,6 +538,7 @@ class Session(RedBase):
         state["session"] = None
         #state["parameters"] = None
         state['scheduler'] = None
+        state['returns'] = None
         return state
 
     def _copy_pickle(self):
@@ -548,8 +549,7 @@ class Session(RedBase):
         new_self = copy(self)
         for attr in unpicklable:
             setattr(new_self, attr, None)
-        # Lines of code suggested to replace exclude use in copy function
-        # copy replaced by model_copy which doesn't allow for exclude
+        
         data = self.config.model_dump(exclude=unpicklable_conf, round_trip=True)
         copied = self.config.model_validate(data)
         new_self.config = copied

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -62,7 +62,7 @@ class Config(BaseModel):
 
     multilaunch: bool = False
     func_run_id: Callable = uuid
-    max_process_count = cpu_count()
+    max_process_count:int = cpu_count()
     tasks_as_daemon: bool = True
     restarting: str = 'replace'
     instant_shutdown: bool = False

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -410,14 +410,14 @@ class Session(RedBase):
         # To avoid circular imports
         from rocketry.tasks import CommandTask, FuncTask
 
-        kwargs['session'] = self
+        # kwargs['session'] = self
 
         if command is not None:
             return CommandTask(command=command, **kwargs)
         if path is not None:
             # Non-wrapped FuncTask
             return FuncTask(path=path, **kwargs)
-        return FuncTask(name_include_module=False, _name_template='{func_name}', **kwargs)
+        return FuncTask(name_include_module=False, _name_template='{func_name}', session=self, **kwargs)
 
     def add_task(self, task: 'Task'):
         "Add the task to the session"

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -548,7 +548,11 @@ class Session(RedBase):
         new_self = copy(self)
         for attr in unpicklable:
             setattr(new_self, attr, None)
-        new_self.config = self.config.copy(exclude=unpicklable_conf)
+        # Lines of code suggested to replace exclude use in copy function
+        # copy replaced by model_copy which doesn't allow for exclude
+        data = self.config.model_dump(exclude=unpicklable_conf, round_trip=True)
+        copied = self.config.model_validate(data)
+        new_self.config = copied
         return new_self
 
     @property

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -536,7 +536,7 @@ class Session(RedBase):
         state["_cond_cache"] = None
         state["_cond_parsers"] = None
         state["session"] = None
-        #state["parameters"] = None
+        # state["parameters"] = None
         state['scheduler'] = None
         state['returns'] = None
         return state

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -71,7 +71,7 @@ class Config(BaseModel):
 
     timeout: datetime.timedelta = datetime.timedelta(minutes=30)
     shut_cond: Optional['BaseCondition'] = None
-    cls_lock: threading.Lock = threading.Lock
+    cls_lock: Callable = threading.Lock
 
     param_materialize:Literal['pre', 'post'] = 'post'
 

--- a/rocketry/session.py
+++ b/rocketry/session.py
@@ -410,14 +410,14 @@ class Session(RedBase):
         # To avoid circular imports
         from rocketry.tasks import CommandTask, FuncTask
 
-        # kwargs['session'] = self
+        kwargs['session'] = self
 
         if command is not None:
             return CommandTask(command=command, **kwargs)
         if path is not None:
             # Non-wrapped FuncTask
             return FuncTask(path=path, **kwargs)
-        return FuncTask(name_include_module=False, _name_template='{func_name}', session=self, **kwargs)
+        return FuncTask(name_include_module=False, _name_template='{func_name}', **kwargs)
 
     def add_task(self, task: 'Task'):
         "Add the task to the session"

--- a/rocketry/tasks/__init__.py
+++ b/rocketry/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .func import FuncTask
 from .code import CodeTask
 from .command import CommandTask
+from ._dummy import _DummyTask
 from . import maintain

--- a/rocketry/tasks/_dummy.py
+++ b/rocketry/tasks/_dummy.py
@@ -1,0 +1,10 @@
+from rocketry.core import Task
+class _DummyTask(Task):
+    """
+    Not used within core application. Only used in UnitTests
+    DummyTask which inherits task and performs forward_refs
+    to allow for use inside unit tests. Provides basic implementation
+    of Task classs and overwrites required abstractmethods.
+    """
+    def execute(self, *args, **kwargs):
+        return

--- a/rocketry/tasks/command.py
+++ b/rocketry/tasks/command.py
@@ -43,9 +43,9 @@ class CommandTask(Task):
 
     command: Union[str, List[str]]
     shell: bool = False
-    cwd: Optional[str]
+    cwd: Optional[str] = None
     kwds_popen: dict = {}
-    argform: Optional[Literal['-', '--', 'short', 'long']] = Field(description="Whether the arguments are turned as short or long form command line arguments")
+    argform: Optional[Literal['-', '--', 'short', 'long']] = Field(description="Whether the arguments are turned as short or long form command line arguments", default=None)
 
     def get_kwargs_popen(self) -> dict:
         kwargs = {

--- a/rocketry/tasks/command.py
+++ b/rocketry/tasks/command.py
@@ -7,7 +7,7 @@ try:
 except ImportError: # pragma: no cover
     from typing_extensions import Literal
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 
 from rocketry.core.parameters.parameters import Parameters
 from rocketry.core.task import Task
@@ -58,7 +58,7 @@ class CommandTask(Task):
         kwargs.update(self.kwds_popen)
         return kwargs
 
-    @validator('argform')
+    @field_validator('argform')
     def parse_argform(cls, value):
         return {
             "long": "--",

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -143,6 +143,8 @@ class FuncTask(Task):
     def delayed(self):
         return self._is_delayed
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator('path')
     def validate_path(cls, value: Path, values):
         name = values['name']
@@ -150,6 +152,8 @@ class FuncTask(Task):
             warnings.warn(f"Path {value} does not exists. Task '{name}' may fail.")
         return value
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("func")
     def validate_func(cls, value, values):
         execution = values.get('execution')

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -2,7 +2,7 @@ import sys
 import inspect
 import importlib
 from pathlib import Path
-from typing import Callable, List, Optional, ClassVar
+from typing import Callable, List, Optional
 import warnings
 
 from pydantic import Field, PrivateAttr, field_validator, field_serializer
@@ -137,7 +137,7 @@ class FuncTask(Task):
     sys_paths: List[Path] = []
 
     _is_delayed: bool = PrivateAttr(default=False)
-    _delayed_kwargs: ClassVar[dict] = {}
+    _delayed_kwargs: dict = {}
     _name_template: str = '{module_name}:{func_name}'
     @property
     def delayed(self):

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from typing import Callable, List, Optional
 import warnings
 
-from pydantic import Field, PrivateAttr, field_validator, field_serializer, BaseModel
+from pydantic import Field, PrivateAttr, field_validator, field_serializer
+from pydantic.main import _object_setattr
 
 from rocketry.core.task import Task
 from rocketry.core.parameters import Parameters
@@ -171,7 +172,6 @@ class FuncTask(Task):
     def __init__(self, func=None, **kwargs):
         only_func_set = func is not None and not kwargs
         no_func_set = func is None and kwargs.get('path') is None
-        from pydantic.main import _object_setattr
         _object_setattr(self, "__pydantic_extra__", {})
         _object_setattr(self, "__pydantic_private__", None)
         if no_func_set:

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable, List, Optional, ClassVar
 import warnings
 
-from pydantic import Field, PrivateAttr, field_validator
+from pydantic import Field, PrivateAttr, field_validator, field_serializer
 
 from rocketry.core.task import Task
 from rocketry.core.parameters import Parameters
@@ -162,6 +162,11 @@ class FuncTask(Task):
                 "The function must be pickleable if task's execution is 'process'. "
             )
         return value
+    
+    @field_serializer("func", when_used="json")
+    def ser_func(self, func):
+        return func.__name__
+
 
     def __init__(self, func=None, **kwargs):
         only_func_set = func is not None and not kwargs

--- a/rocketry/tasks/func.py
+++ b/rocketry/tasks/func.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable, List, Optional, ClassVar
 import warnings
 
-from pydantic import Field, PrivateAttr, validator
+from pydantic import Field, PrivateAttr, field_validator
 
 from rocketry.core.task import Task
 from rocketry.core.parameters import Parameters
@@ -143,20 +143,17 @@ class FuncTask(Task):
     def delayed(self):
         return self._is_delayed
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator('path')
+
+    @field_validator('path')
     def validate_path(cls, value: Path, values):
-        name = values['name']
+        name = values.data['name']
         if value is not None and not value.is_file():
             warnings.warn(f"Path {value} does not exists. Task '{name}' may fail.")
         return value
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("func")
+    @field_validator("func")
     def validate_func(cls, value, values):
-        execution = values.get('execution')
+        execution = values.data.get('execution')
         func = value
 
         if execution == "process" and getattr(func, "__name__", None) == "<lambda>":

--- a/rocketry/test/condition/test_meta.py
+++ b/rocketry/test/condition/test_meta.py
@@ -15,6 +15,7 @@ def is_foo(status):
         return True
     return False
 
+
 @pytest.mark.parametrize("execution", ["main", "thread", "process"])
 def test_taskcond_true(session, execution):
     assert session._cond_cache == {}

--- a/rocketry/test/condition/test_meta.py
+++ b/rocketry/test/condition/test_meta.py
@@ -30,7 +30,7 @@ def test_taskcond_true(session, execution):
     session.config.shut_cond = (TaskStarted(task="a task") >= 2) | ~SchedulerStarted(period="past 5 seconds")
     session.start()
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     history_task = [
         rec
         for rec in records
@@ -73,7 +73,7 @@ def test_taskcond_false(session, execution):
     session.config.shut_cond = SchedulerCycles() >= 3
     session.start()
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     history_task = [
         rec
         for rec in records

--- a/rocketry/test/schedule/test_core.py
+++ b/rocketry/test/schedule/test_core.py
@@ -85,6 +85,7 @@ def test_scheduler_shut_cond(session):
 @pytest.mark.parametrize("execution", ["main", "async", "thread", "process"])
 @pytest.mark.parametrize("func", [pytest.param(create_line_to_file, id="sync"), pytest.param(create_line_to_file_async, id="async")])
 def test_task_execution(tmpdir, execution, func, session):
+
     with tmpdir.as_cwd():
         # To be confident the scheduler won't lie to us
         # we test the task execution with a job that has
@@ -92,7 +93,6 @@ def test_task_execution(tmpdir, execution, func, session):
         FuncTask(func, name="add line to file", start_cond=AlwaysTrue(), execution=execution, session=session)
 
         session.config.shut_cond = (TaskStarted(task="add line to file") >= 3) | ~SchedulerStarted(period=TimeDelta("5 second"))
-
         session.start()
         # Sometimes in CI the task may end up to be started only twice thus we tolerate slightly
         with open("work.txt", "r", encoding="utf-8") as file:
@@ -131,6 +131,7 @@ def test_task_log(tmpdir, execution, task_func, run_count, fail_count, success_c
     """
 
     # Set session (and logging)
+    print("test_task_log")
     session = Session(config={"debug": True, "silence_task_logging": False, "execution": "process"})
     rocketry.session = session
     session.set_as_default()
@@ -188,6 +189,7 @@ def test_task_log(tmpdir, execution, task_func, run_count, fail_count, success_c
 @pytest.mark.parametrize("func_type", ["sync", "async"])
 @pytest.mark.parametrize("execution", ["main", "thread", "process"])
 def test_task_status(session, execution, func_type, mode):
+    print("test_task_status")
     session.config.force_status_from_logs = mode == "use logs"
 
     task_success = FuncTask(
@@ -272,6 +274,7 @@ def test_task_status(session, execution, func_type, mode):
 
 @pytest.mark.parametrize("execution", ["main", "thread", "process"])
 def test_task_disabled(tmpdir, execution, session):
+    print("test_task_disabled")
     with tmpdir.as_cwd():
 
         task = FuncTask(
@@ -293,6 +296,7 @@ def test_task_disabled(tmpdir, execution, session):
 
 @pytest.mark.parametrize("execution", ["main", "thread", "process"])
 def test_priority(execution, session):
+    print("test_task_priority")
     session.config.max_process_count = 4
     task_1 = FuncTask(run_succeeding, name="1", priority=100, start_cond=AlwaysTrue(), execution=execution, session=session)
     task_3 = FuncTask(run_failing, name="3", priority=10, start_cond=AlwaysTrue(), execution=execution, session=session)
@@ -315,6 +319,7 @@ def test_priority(execution, session):
 
 @pytest.mark.parametrize("execution", ["main", "thread", "process"])
 def test_pass_params_as_global(execution, session):
+    print("test_pass_params_as_global")
     # thread-Parameters has been observed to fail rarely
 
     task = FuncTask(run_with_param, name="parametrized", start_cond=AlwaysTrue(), execution=execution, session=session)

--- a/rocketry/test/schedule/test_core.py
+++ b/rocketry/test/schedule/test_core.py
@@ -159,7 +159,7 @@ def test_task_log(tmpdir, execution, task_func, run_count, fail_count, success_c
     for record in history:
         is_tasl_log = isinstance(record, TaskLogRecord)
         if not isinstance(record, dict):
-            record = record.dict()
+            record = record.model_dump()
         assert record["task_name"] == "mytask"
         assert isinstance(record["created"], float)
         assert isinstance(record["start"], datetime.datetime if is_tasl_log else float)

--- a/rocketry/test/schedule/test_failure.py
+++ b/rocketry/test/schedule/test_failure.py
@@ -69,7 +69,7 @@ def test_param_failure(tmpdir, execution, session, fail_in):
     session.start()
     assert task.status == "fail"
 
-    records = list(map(lambda d: d.dict(exclude={'created'}), task.logger.get_records()))
+    records = list(map(lambda d: d.model_dump(exclude={'created'}), task.logger.get_records()))
     assert [{"task_name": "a task", "action": "run"}, {"task_name": "a task", "action": "fail"}] == records
 
 @pytest.mark.parametrize(
@@ -93,7 +93,7 @@ def test_session_param_failure(tmpdir, execution, session, fail_in):
     session.start()
     assert task.status == "fail"
 
-    records = list(map(lambda d: d.dict(exclude={'created'}), task.logger.get_records()))
+    records = list(map(lambda d: d.model_dump(exclude={'created'}), task.logger.get_records()))
     assert [{"task_name": "a task", "action": "run"}, {"task_name": "a task", "action": "fail"}] == records
 
 

--- a/rocketry/test/session/test_logs.py
+++ b/rocketry/test/session/test_logs.py
@@ -3,7 +3,7 @@ from itertools import chain
 import datetime
 import logging
 from typing import Optional
-from pydantic import field_validator, root_validator, model_validator
+from pydantic import field_validator, model_validator
 
 import pytest
 
@@ -51,7 +51,7 @@ class CustomRecord(MinimalRecord):
         if value is not None:
             return datetime.datetime.fromtimestamp(value)
 
-    @root_validator(skip_on_failure=True)
+    @model_validator(mode="before")
     def validate_timestamp(cls, values):
         values['timestamp'] = datetime.datetime.fromtimestamp(values['created'])
         return values
@@ -260,7 +260,7 @@ def test_get_logs_params(tmpdir, mock_pydatetime, mock_time, query, expected, se
 
         logs = list(logs)
         assert len(expected) == len(logs)
-        logs = list(map(lambda e: e.dict(), logs))
+        logs = list(map(lambda e: e.model_dump(), logs))
         for e, a in zip(expected, logs):
             #assert e.keys() <= a.keys()
             # Check all expected items in actual (actual can contain extra)

--- a/rocketry/test/session/test_logs.py
+++ b/rocketry/test/session/test_logs.py
@@ -3,7 +3,7 @@ from itertools import chain
 import datetime
 import logging
 from typing import Optional
-from pydantic import root_validator, validator
+from pydantic import field_validator, root_validator, model_validator
 
 import pytest
 
@@ -33,23 +33,25 @@ def do_fail():
     raise RuntimeError("Oops")
 
 class CustomRecord(MinimalRecord):
-    timestamp: Optional[datetime.datetime]
-    start: Optional[datetime.datetime]
-    end: Optional[datetime.datetime]
-    runtime: Optional[datetime.timedelta]
+    timestamp: Optional[datetime.datetime] = None
+    start: Optional[datetime.datetime] = None
+    end: Optional[datetime.datetime] = None
+    runtime: Optional[datetime.timedelta] = None
     message: str
 
-    @validator("start", pre=True)
+    @field_validator("start", mode="before")
+    @classmethod
     def parse_start(cls, value):
         if value is not None:
             return datetime.datetime.fromtimestamp(value)
 
-    @validator("end", pre=True)
+    @field_validator("end", mode="before")
+    @classmethod
     def parse_end(cls, value):
         if value is not None:
             return datetime.datetime.fromtimestamp(value)
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def validate_timestamp(cls, values):
         values['timestamp'] = datetime.datetime.fromtimestamp(values['created'])
         return values

--- a/rocketry/test/task/code/test_construct.py
+++ b/rocketry/test/task/code/test_construct.py
@@ -80,6 +80,6 @@ def test_run_fail(session, execution):
 
     assert task.status == 'fail'
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     record_fail = [r for r in records if r['action'] == 'fail'][0]
     assert 'File "<string>", line 5, in <module>\n  File "<string>", line 3, in main\nRuntimeError: Failed' in record_fail['exc_text']

--- a/rocketry/test/task/command/test_run.py
+++ b/rocketry/test/task/command/test_run.py
@@ -77,8 +77,10 @@ def test_fail_command(tmpdir, execution, session):
 
         err = records[1]["exc_text"].strip().replace('\r', '')
         if sys.version_info >= (3, 8):
-            expected = "OSError: Failed running command (2): \nunknown option --not_an_arg\nusage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...\nTry `python -h' for more information."
-            assert err.endswith(expected)
+            # Somethings the file path in before 'python' changing endswith to two in statements instead
+            assert "OSError: Failed running command (2): \nunknown option --not_an_arg\nusage:" in err and "python [option] ... [-c cmd | -m mod | file | -] [arg] ...\nTry `python -h' for more information." in err
+            # expected = "OSError: Failed running command (2): \nunknown option --not_an_arg\nusage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...\nTry `python -h' for more information."
+            # assert err.endswith(expected)
         else:
             assert err.endswith("Try `python -h' for more information.")
             assert "OSError: Failed running command (2)" in err

--- a/rocketry/test/task/command/test_run.py
+++ b/rocketry/test/task/command/test_run.py
@@ -72,7 +72,7 @@ def test_fail_command(tmpdir, execution, session):
 
         wait_till_task_finish(task)
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert "fail" == task.status
 
         err = records[1]["exc_text"].strip().replace('\r', '')

--- a/rocketry/test/task/func/test_export.py
+++ b/rocketry/test/task/func/test_export.py
@@ -4,9 +4,9 @@ def test_to_dict(session):
     task1 = FuncTask(func=lambda: None, name="task 1", start_cond="every 10 seconds", session=session)
     task2 = FuncTask(func=lambda: None, name="task 2", start_cond="after task 'task 1'", session=session)
 
-    task1.dict()
-    task2.dict()
+    task1.model_dump()
+    task2.model_dump()
 
-    task1.json()
-    task2.json()
+    task1.model_dump_json()
+    task2.model_dump_json()
     pass

--- a/rocketry/test/task/func/test_logging.py
+++ b/rocketry/test/task/func/test_logging.py
@@ -150,7 +150,7 @@ def test_handle(session):
 
     records = session.get_task_log()
     records = [
-        record.dict(exclude={"created"})
+        record.model_dump(exclude={"created"})
         for record in records
     ]
     assert [

--- a/rocketry/test/task/func/test_logging.py
+++ b/rocketry/test/task/func/test_logging.py
@@ -275,7 +275,7 @@ def test_action_start(tmpdir, method, session):
     task.log_running()
     getattr(task, method)()
 
-    records = list(map(lambda e: e.dict(), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(), session.get_task_log()))
     assert len(records) == 2
 
     # First should not have "end"

--- a/rocketry/test/task/func/test_run.py
+++ b/rocketry/test/task/func/test_run.py
@@ -297,7 +297,7 @@ def test_parametrization_kwargs(session):
 
     task()
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     assert [
         {"task_name": "a task", "action": "run"},
         {"task_name": "a task", "action": "success"},

--- a/rocketry/test/task/func/test_run.py
+++ b/rocketry/test/task/func/test_run.py
@@ -73,7 +73,7 @@ def test_run(task_func, expected_outcome, exc_cls, execution, session):
 
     assert task.status == expected_outcome
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     assert [
         {"task_name": "a task", "action": "run"},
         {"task_name": "a task", "action": expected_outcome},
@@ -119,7 +119,7 @@ def test_run_async(task_func, expected_outcome, execution, session):
 
     assert task.status == expected_outcome
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     assert [
         {"task_name": "a task", "action": "run"},
         {"task_name": "a task", "action": expected_outcome},
@@ -261,7 +261,7 @@ def test_parametrization_runtime(session):
 
     task(params={"integer": 1, "string": "X", "optional_float": 1.1, "extra_parameter": "Should not be passed"})
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     assert [
         {"task_name": "a task", "action": "run"},
         {"task_name": "a task", "action": "success"},
@@ -279,7 +279,7 @@ def test_parametrization_local(session):
 
     task()
 
-    records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+    records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
     assert [
         {"task_name": "a task", "action": "run"},
         {"task_name": "a task", "action": "success"},

--- a/rocketry/test/task/func/test_run_delayed.py
+++ b/rocketry/test/task/func/test_run_delayed.py
@@ -47,7 +47,7 @@ def test_run(tmpdir, script_files, script_path, expected_outcome, exc_cls, execu
 
         assert task.status == expected_outcome
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": expected_outcome},
@@ -72,7 +72,7 @@ def test_run_specified_func(tmpdir, session):
         )
         task()
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -102,7 +102,7 @@ def test_import_relative(tmpdir, session):
         )
         task()
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -136,7 +136,7 @@ def test_import_package(tmpdir, session):
         )
         task()
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -166,7 +166,7 @@ def test_import_relative_with_params(tmpdir, session):
         )
         task(params={"val_5":5})
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -199,7 +199,7 @@ def test_additional_sys_paths(tmpdir, session):
         )
         task(params={"val_5":5})
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -219,7 +219,7 @@ def test_parametrization_runtime(tmpdir, script_files, session):
 
         task(params={"integer": 1, "string": "X", "optional_float": 1.1, "extra_parameter": "Should not be passed"})
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -239,7 +239,7 @@ def test_parametrization_local(tmpdir, script_files, session):
 
         task()
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},
@@ -259,7 +259,7 @@ def test_parametrization_kwargs(tmpdir, script_files, session):
 
         task()
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), session.get_task_log()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), session.get_task_log()))
         assert [
             {"task_name": "a task", "action": "run"},
             {"task_name": "a task", "action": "success"},

--- a/rocketry/test/task/misc/test_restart.py
+++ b/rocketry/test/task/misc/test_restart.py
@@ -36,7 +36,7 @@ def test_scheduler_restart(tmpdir, session):
             cont = f.read()
         assert "StartedShutStartedShut" == cont
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), task.logger.get_records()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), task.logger.get_records()))
         assert 1 == len([record for record in records if record["action"] == "run"])
         assert 1 == len([record for record in records if record["action"] == "success"])
 

--- a/rocketry/test/task/misc/test_shutdown.py
+++ b/rocketry/test/task/misc/test_shutdown.py
@@ -33,6 +33,6 @@ def test_scheduler_shutdown(tmpdir, session):
             cont = f.read()
         assert "StartedShut" == cont
 
-        records = list(map(lambda e: e.dict(exclude={'created'}), task.logger.get_records()))
+        records = list(map(lambda e: e.model_dump(exclude={'created'}), task.logger.get_records()))
         assert 1 == len([record for record in records if record["action"] == "run"])
         assert 1 == len([record for record in records if record["action"] == "success"])

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -3,9 +3,11 @@ import logging
 import pickle
 from textwrap import dedent
 from typing import ClassVar
+from pydantic import SkipValidation
 import pytest
 from rocketry.args.builtin import Return
 from rocketry.core import Task as BaseTask
+# from rocketry.tasks import FuncTask as BaseTask
 from rocketry.core.condition.base import AlwaysFalse
 from rocketry.args import Arg, Session, Task
 from rocketry.exc import TaskLoggingError

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -100,7 +100,7 @@ def test_crash(session):
     assert [
         {'action': 'run', 'task_name': 'mytest'},
         {'action': 'crash', 'task_name': 'mytest'}
-    ] == [log.dict(exclude={'created'}) for log in logs]
+    ] == [log.model_dump(exclude={'created'}) for log in logs]
 
 def test_json(session):
     session.parameters['x'] = 5

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -7,6 +7,7 @@ from pydantic import Field, BaseModel
 import pytest
 from rocketry.args.builtin import Return
 from rocketry.core import Task as BaseTask
+from rocketry.tasks import _DummyTask
 from rocketry.core.condition.base import AlwaysFalse
 from rocketry.args import Arg, Session, Task
 from rocketry.exc import TaskLoggingError
@@ -14,48 +15,38 @@ from rocketry.log import MinimalRecord
 from rocketry import Session as SessionClass
 from rocketry.testing.log import create_task_record
 
-class DummyTask(BaseTask):
-
-    session: ClassVar
-
-    def execute(self, *args, **kwargs):
-        return
-    
-    def get_default_name(self, **kwargs):
-        pass
-
 def test_defaults(session):
 
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     assert task.name == "mytest"
     assert isinstance(task.start_cond, AlwaysFalse)
     assert isinstance(task.end_cond, AlwaysFalse)
 
 def test_defaults_no_session(session):
     with pytest.warns(UserWarning):
-        task = DummyTask(name="mytest")
+        task = _DummyTask(name="mytest")
     assert task.session is not session
     assert isinstance(task.session, SessionClass)
     assert task.session.tasks == {task}
 
 def test_set_timeout(session):
-    task = DummyTask(session=session, timeout="1 hour 20 min", name="1")
+    task = _DummyTask(session=session, timeout="1 hour 20 min", name="1")
     assert task.timeout == datetime.timedelta(hours=1, minutes=20)
 
-    task = DummyTask(timeout=datetime.timedelta(hours=1, minutes=20), session=session, name="2")
+    task = _DummyTask(timeout=datetime.timedelta(hours=1, minutes=20), session=session, name="2")
     assert task.timeout == datetime.timedelta(hours=1, minutes=20)
 
-    task = DummyTask(timeout=20, session=session, name="3")
+    task = _DummyTask(timeout=20, session=session, name="3")
     assert task.timeout == datetime.timedelta(seconds=20)
 
 def test_delete(session):
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     assert session.tasks == {task}
     task.delete()
     assert session.tasks == set()
 
 def test_set_invalid_status(session):
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     with pytest.raises(ValueError):
         task.status = "not valid"
 
@@ -66,7 +57,7 @@ def test_failed_logging(session):
             raise RuntimeError("Oops")
 
     logging.getLogger("rocketry.task").handlers.insert(0, MyHandler())
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     for func in (task.log_crash, task.log_failure, task.log_success, task.log_inaction, task.log_termination):
         with pytest.raises(TaskLoggingError):
             func()
@@ -77,13 +68,13 @@ def test_failed_logging(session):
         task.log_record(record) # Used by process logging
 
 def test_pickle(session):
-    task_1 = DummyTask(name="mytest", session=session)
+    task_1 = _DummyTask(name="mytest", session=session)
     pkl_obj = pickle.dumps(task_1)
     task_2 = pickle.loads(pkl_obj)
     assert task_1.name == task_2.name
 
 def test_crash(session):
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     task.set_cached()
     task.log_running()
     assert task.status == "run"
@@ -91,7 +82,7 @@ def test_crash(session):
     task.delete()
 
     # Recreating and now should log crash
-    task = DummyTask(name="mytest", session=session)
+    task = _DummyTask(name="mytest", session=session)
     task.set_cached()
     assert task.status == "crash"
     assert task.last_crash
@@ -108,7 +99,7 @@ def test_json(session):
     repo.add(MinimalRecord(task_name="mytest", action="run", created=1640988000))
     repo.add(MinimalRecord(task_name="mytest", action="success", created=1640988060))
 
-    task = DummyTask(name="mytest", parameters={
+    task = _DummyTask(name="mytest", parameters={
         "arg_2": Arg("x"),
         "arg_2": Return("another"),
         "session": Session(),
@@ -116,7 +107,10 @@ def test_json(session):
         "another_task": Task('another')
     }, session=session)
     task.set_cached()
-    j = task.json(indent=4)
+    # Deleting session from this test. Session is a random ID each time
+    # With pydantic changes it includes it in serialization
+    delattr(task, "session")
+    j = task.model_dump_json(indent=4)
 
     dt_run = datetime.datetime.fromtimestamp(1640988000)
     dt_success = datetime.datetime.fromtimestamp(1640988060)

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import pickle
 from textwrap import dedent
+from typing import ClassVar
 import pytest
 from rocketry.args.builtin import Return
 from rocketry.core import Task as BaseTask
@@ -14,6 +15,7 @@ from rocketry.testing.log import create_task_record
 
 class DummyTask(BaseTask):
 
+    session: ClassVar
     def execute(self, *args, **kwargs):
         return
 

--- a/rocketry/test/task/test_core.py
+++ b/rocketry/test/task/test_core.py
@@ -2,12 +2,11 @@ import datetime
 import logging
 import pickle
 from textwrap import dedent
-from typing import ClassVar
-from pydantic import SkipValidation
+from typing import ClassVar, Generic, Any
+from pydantic import Field, BaseModel
 import pytest
 from rocketry.args.builtin import Return
 from rocketry.core import Task as BaseTask
-# from rocketry.tasks import FuncTask as BaseTask
 from rocketry.core.condition.base import AlwaysFalse
 from rocketry.args import Arg, Session, Task
 from rocketry.exc import TaskLoggingError
@@ -18,10 +17,15 @@ from rocketry.testing.log import create_task_record
 class DummyTask(BaseTask):
 
     session: ClassVar
+
     def execute(self, *args, **kwargs):
         return
+    
+    def get_default_name(self, **kwargs):
+        pass
 
 def test_defaults(session):
+
     task = DummyTask(name="mytest", session=session)
     assert task.name == "mytest"
     assert isinstance(task.start_cond, AlwaysFalse)
@@ -35,7 +39,7 @@ def test_defaults_no_session(session):
     assert task.session.tasks == {task}
 
 def test_set_timeout(session):
-    task = DummyTask(timeout="1 hour 20 min", session=session, name="1")
+    task = DummyTask(session=session, timeout="1 hour 20 min", name="1")
     assert task.timeout == datetime.timedelta(hours=1, minutes=20)
 
     task = DummyTask(timeout=datetime.timedelta(hours=1, minutes=20), session=session, name="2")

--- a/rocketry/test/test_hooks.py
+++ b/rocketry/test/test_hooks.py
@@ -1,5 +1,6 @@
 from functools import partial
 from textwrap import dedent
+from typing import ClassVar
 import sys
 
 import pytest
@@ -38,6 +39,8 @@ def test_task_init(session):
         timeline.append("Generator hook called (post)")
 
     class DummyTask(Task):
+
+        session: ClassVar
 
         def execute(self, *args, **kwargs):
             return

--- a/rocketry/test/test_hooks.py
+++ b/rocketry/test/test_hooks.py
@@ -8,7 +8,7 @@ from rocketry.conditions.task.task import DependSuccess, TaskStarted
 from rocketry.core import Task, Scheduler
 from rocketry.session import Session
 
-from rocketry.tasks import FuncTask
+from rocketry.tasks import FuncTask, _DummyTask
 from rocketry.conditions import SchedulerCycles
 from rocketry.conds import true
 
@@ -26,30 +26,24 @@ def test_task_init(session):
     @session.hook_task_init()
     def myhook(task=TaskArg()):
         timeline.append("Function hook called")
-        assert isinstance(task, DummyTask)
+        assert isinstance(task, _DummyTask)
         assert not hasattr(task, "name") # Should not yet have created this attr
 
     @session.hook_task_init()
     def mygenerhook(task=TaskArg()):
         timeline.append("Generator hook called (pre)")
-        assert isinstance(task, DummyTask)
+        assert isinstance(task, _DummyTask)
         assert not hasattr(task, "name") # Should not yet have created this attr
         yield
         assert hasattr(task, "session") # Should now have it
         timeline.append("Generator hook called (post)")
 
-    class DummyTask(Task):
-
-        session: ClassVar
-
-        def execute(self, *args, **kwargs):
-            return
 
 
     assert session.hooks.task_init == [myhook, mygenerhook] # The func is in different namespace thus different
 
     timeline.append("Main")
-    mytask = DummyTask(name="dummy", session=session)
+    mytask = _DummyTask(name="dummy", session=session)
     assert timeline == [
         "Main",
         "Function hook called",

--- a/rocketry/utils/dependencies.py
+++ b/rocketry/utils/dependencies.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from rocketry.conditions import Any, All, DependFinish, DependSuccess
 from rocketry.conditions.task import DependFailure
@@ -43,8 +43,7 @@ class Link:
         return f'Link({self.parent.name!r}, {self.child.name!r}, relation={getattr(self.relation, "__name__", None)}, type={getattr(self.type, "__name__", None)})'
 
 class Dependencies(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     session: Session
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,3 +64,7 @@ deps =
 # install_command = pip install --upgrade build
 commands = python setup.py bdist_wheel sdist
            twine upload -r testpypi dist/*
+
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:redbird.*

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,3 @@ deps =
 # install_command = pip install --upgrade build
 commands = python setup.py bdist_wheel sdist
            twine upload -r testpypi dist/*
-
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:redbird.*


### PR DESCRIPTION
Attempting to start work on the PydanticV2 migration.

Changes made so far:  
- Temporarily comment out RedBase session attribute as it was causing issues with re-writing the value - This needs reviewing to find an alternate fix
- Converted update_forward_refs to model_rebuild in _setup.py
- set type on mac_process_count in sessions.py
- Implemented ClassVar when dealing with session variable to fix inheritence
- Convert Config Meta Class into model_config attribute
- set default values Task class as in pydanticv2 they were set to required=True as default
- _delayed_kwargs now ClassVar to be passed correctly

Pretty much all the tests still fail and this needs heavily reviewing. I'll continue to work on this PR to assist.
As it stands with this version of the code a basic hello_world task can be run.

```
from rocketry import Rocketry

app = Rocketry()

@app.task("every 3 seconds")
def do_things():
    print("hello world")

if __name__ == "__main__":
    app.run()
```

This is with PydanticV2 (2.0.3) and installing ManiMozaffar red-bird branch which has quick fixes to append .v1 to the pydantic imports.

Will continue to work on making tests pass with v2 installed.